### PR TITLE
fix_tmp_tbl_no_pk

### DIFF
--- a/src/main/java/com/teradata/fivetran/destination/TeradataJDBCUtil.java
+++ b/src/main/java/com/teradata/fivetran/destination/TeradataJDBCUtil.java
@@ -351,7 +351,7 @@ public class TeradataJDBCUtil {
      * @param columns The list of columns.
      * @return The column definitions.
      */
-    static String getColumnDefinitions(List<Column> columns) {
+    public static String getColumnDefinitions(List<Column> columns) {
         List<String> columnsDefinitions = columns.stream().map(TeradataJDBCUtil::getColumnDefinition).collect(Collectors.toList());
 
         List<String> primaryKeyColumns = columns.stream().filter(Column::getPrimaryKey)


### PR DESCRIPTION
Fix for temp table not having the PK that the target table has

"CREATE MULTISET TABLE %s AS (SELECT * FROM %s) WITH NO DATA;" will not copy the PK columns.
