### PR TITLE
Enable CRL Distribution Point checking for SSL

### DIFF
--- a/src/main/java/com/teradata/fivetran/destination/TeradataDestination.java
+++ b/src/main/java/com/teradata/fivetran/destination/TeradataDestination.java
@@ -20,6 +20,9 @@ public class TeradataDestination {
      */
     public static void main(String[] args) throws InterruptedException, IOException {
 
+        // Enable CRL Distribution Point checking for SSL certificate validation
+        System.setProperty("com.sun.security.enableCRLDP", "true");
+
         // Create Options object
         Options options = new Options();
         options.addOption("p", "port", true, "Port to run the gRPC server");


### PR DESCRIPTION
  ## Summary
  - Set `com.sun.security.enableCRLDP=true` as a system property at startup in
    `TeradataDestination.main()` so the JVM can download and verify Certificate
    Revocation Lists when `ssl.mode` is `VERIFY-CA` or `VERIFY-FULL`
  - Replaces the need to pass `-Dcom.sun.security.enableCRLDP=true` as a JVM flag
    during deployment, ensuring it works correctly in Fivetran's binary build pipeline
  - No impact on non-certificate-validating SSL modes (`DISABLE`, `ALLOW`, `PREFER`,
    `REQUIRE`) — the flag is only used during certificate validation