### PR TITLE
Fix FastLoad failure when database config differs from JDBC user home

### DIFF
--- a/src/main/java/com/teradata/fivetran/destination/writers/FastLoadDataWriter.java
+++ b/src/main/java/com/teradata/fivetran/destination/writers/FastLoadDataWriter.java
@@ -191,7 +191,18 @@ public class FastLoadDataWriter {
                     createTempTableSQL , e);
         }
 
-        String beginLoading = String.format("BEGIN LOADING %s ERRORFILES %s, %s WITH INTERVAL", outputTableName, errorTable1, errorTable2);
+        // Qualify temp + ERR table names with the target database. The FastLoad
+        // session (lsnConnection) is opened without a default-database setting,
+        // so its default database is the JDBC user's home. When `database` config
+        // points elsewhere (e.g. configurationMap.database != user-home), an
+        // unqualified BEGIN LOADING resolves to the wrong table and Teradata
+        // rejects it with Error 3614 ("Statement permitted only during FastLoad
+        // or MLoad") because the LSN reservation was made for a table in the
+        // configured database.
+        String beginLoading = String.format("BEGIN LOADING %s ERRORFILES %s, %s WITH INTERVAL",
+                TeradataJDBCUtil.escapeTable(database, outputTableName),
+                TeradataJDBCUtil.escapeTable(database, errorTable1),
+                TeradataJDBCUtil.escapeTable(database, errorTable2));
         String endLoading = "END LOADING";
 
         String lsnUrl = "jdbc:teradata://" + dbsHost
@@ -363,9 +374,17 @@ public class FastLoadDataWriter {
              Logger.logMessage(Logger.LogLevel.INFO,"\nTASM Governed: " + governedValue);
             boolean isGoverned = "true".equals(governedValue);
 
-            // Build check workload statement
-            String checkWorkload = CHECK_WORKLOAD + SQL_BEGIN_LOADING + " " + outputTableName
-                    + " ERRORFILES " + errorTable1 + ", " + errorTable2;
+            // Build check workload statement. Qualify table names with the
+            // target database for the same reason as BEGIN LOADING above:
+            // unqualified names resolve against the JDBC user's home database,
+            // which is wrong when the connector is configured to use a
+            // different database via configurationMap.database.
+            String checkWorkload = CHECK_WORKLOAD + SQL_BEGIN_LOADING + " "
+                    + TeradataJDBCUtil.escapeTable(database, outputTableName)
+                    + " ERRORFILES "
+                    + TeradataJDBCUtil.escapeTable(database, errorTable1)
+                    + ", "
+                    + TeradataJDBCUtil.escapeTable(database, errorTable2);
 
             String checkWorkloadEnd = (!isGoverned ? "{fn teradata_failfast}" : "") + CHECK_WORKLOAD_END;
 


### PR DESCRIPTION
FastLoad writeBatch/writeHistoryBatch was failing with Teradata Error 3614 ("Statement permitted only during FastLoad or MLoad") whenever configurationMap.database pointed to a database other than the JDBC user's home database (e.g. user=mt255026, database=junit).

Root cause: BEGIN LOADING and CHECK WORKLOAD FOR BEGIN LOADING used unqualified table names (e.g. 'td_tmp_xxx'). The lsnConnection used for FastLoad is opened without a default-database setting, so its default database is the JDBC user's home, NOT the configured database. The temp table is created in the configured database via a qualified CREATE, but the unqualified BEGIN LOADING resolves against the wrong database. The LSN was reserved for the configured-database table, so Teradata rejects the BEGIN LOADING with 3614 (no FastLoad in progress for that resolved table).

Fix: qualify both statements with TeradataJDBCUtil.escapeTable(database, <name>) so they target the same database where the temp table actually lives.

Discovered via the SDK Tester Matrix (IDE-26063): all 3 use.fastload combos were silently producing empty target tables when run against a non-default database. Schema migrations succeeded (they ran on the main JDBC connection which honored database=junit), but the FastLoad step silently failed and the subsequent INSERT-SELECT from the missing temp table inserted zero rows. Connector logged "Insert operation completed successfully" because the SQL itself didn't error - SELECT FROM a non-existent table after the failed FastLoad path raised 3807, which was caught and logged at SEVERE but not surfaced to the writeBatch response.

No behavioural change for the default case (database = user-home); qualified names resolve identically to unqualified ones in that case.