### PR TITLE
IDE-26063: SDK Tester Matrix + IDE-26074: FastLoad qualified-name fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 # Snyk scan artifacts (scripts/snyk_scan.py writes into --out; CLI default is repo root)
 /snyk-*-report.json
 /snyk-*-report.sarif.json
+
+# Python bytecode (scripts/sdk_tester_matrix/run.py imports patch_tester_inputs)
+__pycache__/
+*.pyc

--- a/docs/sdk-tester-matrix-guide.md
+++ b/docs/sdk-tester-matrix-guide.md
@@ -1,0 +1,237 @@
+# SDK Tester Matrix — User Guide
+
+## What it is
+
+A single-command runner for the Fivetran SDK destination-connector-tester against the Teradata destination connector. Replaces the manual 12-step ritual of running each `(input × config)` combo by hand and spot-checking tables in BTEQ.
+
+The matrix covers every combination that matters for a release sign-off:
+
+| Input file                                 | TMODE=ANSI | TMODE=TERA | use.fastload=true |
+| ------------------------------------------ | ---------- | ---------- | ----------------- |
+| `input.json`                               | ✓          | ✓          | ✓ (LOB-stripped)  |
+| `schema_migrations_input_ddl.json`         | ✓          | ✓          | ✓                 |
+| `schema_migrations_input_dml.json`         | ✓          | ✓          | ✓                 |
+| `schema_migrations_input_sync_modes.json`  | ✓          | ✓          | ✓                 |
+
+12 combos by default. The connector JAR stays running across all of them — TMODE and `use.fastload` are read per-request from the gRPC `configurationMap`, so no JVM restart is needed.
+
+## Why use it
+
+- One command, ~28 minutes wall clock, vs. half a day of manual work.
+- Catches **silent failures** like IDE-26074, where the connector reports success but tables are empty — manual spot-checks miss these.
+- Reproducible: same expectations every run, no human variance.
+- Post-mortem-friendly: every BTEQ script + tester log is archived per combo.
+
+## Prerequisites
+
+| Tool            | Why                                              | Where to get it                                     |
+| --------------- | ------------------------------------------------ | --------------------------------------------------- |
+| Python 3.7+     | Orchestrator (stdlib only — no `pip install`)    | [python.org](https://www.python.org)                |
+| BTEQ            | Validation queries against Teradata              | Teradata Tools and Utilities (TTU)                  |
+| Docker          | Runs the SDK tester image                        | Docker Desktop (Windows) / docker-ce (Linux)        |
+| Connector JAR   | Service under test (port 50052)                  | `gradle jar` → `build/libs/TeradataDestination.jar` |
+
+Environment variables (mirror what `gradle test` already uses):
+
+```
+TERADATA_HOST       Teradata host (IP or DNS, optionally :port)
+TERADATA_USER       Teradata username
+TERADATA_PASSWORD   Teradata password
+TERADATA_DATABASE   Target database (used by BTEQ for cleanup + assertions; also forwarded to the connector)
+```
+
+## Quick Start
+
+1. **Build the JAR**:
+   ```
+   gradle jar
+   ```
+
+2. **Start the connector** in one terminal — it stays running across all 12 combos:
+   ```
+   java -jar build/libs/TeradataDestination.jar
+   ```
+
+3. **Set env vars** in a second terminal:
+   ```
+   export TERADATA_HOST=<your-teradata-host>
+   export TERADATA_USER=<your-username>
+   export TERADATA_PASSWORD=<your-password>
+   export TERADATA_DATABASE=<your-database>
+   ```
+
+4. **Run the matrix**:
+   ```
+   python scripts/sdk_tester_matrix/run.py
+   ```
+
+5. **Read the report** at the end. Exit code 0 = ship it. Exit code 1 = read the failures section + open the named log.
+
+## How a run works
+
+For each combo, in order:
+
+1. **Probe** `127.0.0.1:50052` — hard-fails fast if the JAR isn't up (exit 2).
+2. **Drop** the 10 known `tester_*` tables (idempotent — "doesn't exist" is silent).
+3. **Write `configuration.json`** to the docker mount source with the combo's `tmode` + `use.fastload` + connection settings. The tester reads this file at runtime and forwards its contents as the gRPC `configurationMap`. An archive copy is kept under `<generated_dir>/configurations/<combo_id>.json`.
+4. **Patch the input JSON**:
+   - Auto-fix `[B@xxx` byte[].toString() junk (reuses `scripts/patch_tester_inputs.py`).
+   - For `input.json × FastLoad` only: strip BLOB/JSON/XML columns (workaround for FastLoad LOB pre-flight gap).
+   - Write the patched copy to the mount source so docker can see it via the bind mount.
+5. **Run** the SDK tester docker container, streaming logs to stderr and to `<generated_dir>/tester-logs/<combo_id>.log`.
+6. **Validate** by running the combo's expectation file (`expectations/<input>.json` or `expectations/<input>.fastload.json`) as one BTEQ script. Each assertion is wrapped as `SELECT COUNT(*) FROM (<your_sql>) bad_` — pass iff count is 0.
+7. **Record** the combo result.
+
+After all combos finish: console matrix table (stdout), full `results.json` for post-mortem.
+
+## CLI Reference
+
+```
+python scripts/sdk_tester_matrix/run.py [OPTIONS]
+```
+
+| Flag                   | Effect                                                              |
+| ---------------------- | ------------------------------------------------------------------- |
+| `--only <csv>`         | Run a subset (combo IDs are `<input_name>__<config_id>`, comma-separated). E.g. `--only input__FastLoad,dml__TERA`. |
+| `--fail-fast`          | Stop on the first combo failure. Default: keep going for a complete view. |
+| `--dry-run`            | Print the planned combos and exit. Useful for sanity-checking config changes. |
+| `--purge-generated`    | Delete `<generated_dir>` at end of a fully-passing run.            |
+| `--config <path>`      | Use a custom config file. Default: `scripts/sdk_tester_matrix/config.json`. |
+
+### Exit codes
+
+| Code | Meaning                                                                |
+| ---- | ---------------------------------------------------------------------- |
+| 0    | Every combo passed (tester rc=0 + every assertion's bad-rows count is 0) |
+| 1    | At least one combo failed validation or the tester                     |
+| 2    | Orchestrator fault: bad config, missing env var, missing CLI tool, port unreachable, BTEQ logon failure |
+
+## Reading the report
+
+Streamed during the run (to stderr):
+
+```
+[1/12] input × ANSI       … tester rc=0 in 39s, validating … 5/5 assertions pass
+[2/12] input × TERA       … tester rc=0 in 41s, validating … 5/5 assertions pass
+[3/12] input × FastLoad   … tester rc=0 in 47s, validating … 4/5 assertions pass
+```
+
+Final summary (stdout):
+
+```
+================================================================================
+ SDK Tester Matrix — 2026-05-06 10:45:06 — image sdk-tester:2.26.0410.001
+================================================================================
+ #   Input              Config     Tester Validate Duration Log
+ --- ------------------ ---------- ------ -------- -------- ----------------
+ 1   input              ANSI       PASS   PASS     01:59    input__ANSI.log
+ ...
+ --- ------------------ ---------- ------ -------- -------- ----------------
+ PASS: 12/12   FAIL: 0/12   total 28:22
+```
+
+If anything fails, the failures section names the combo and the assertion that bombed:
+
+```
+Failures:
+ #3  input/FastLoad    no soft-deleted rows in base table (got 1)
+```
+
+Then open `<generated_dir>/bteq/<combo_id>__assert.log` to see which `MATRIXASSERT_NNN` row had a count > 0.
+
+## Generated artifacts
+
+```
+<generated_dir>/
+├── configurations/<combo_id>.json    # archive of configuration.json used
+├── inputs/<combo_id>.json            # patched input handed to docker
+├── tester-logs/<combo_id>.log        # captured tester stdout+stderr
+├── bteq/<combo_id>__drop.sql/log     # cleanup script + output
+├── bteq/<combo_id>__assert.sql/log   # validation script + output
+└── results.json                      # final structured report
+```
+
+These are kept by default (post-mortem useful). Use `--purge-generated` to delete on a fully-passing run.
+
+## Adding a new test case
+
+The matrix is data-driven. To add a 5th input:
+
+1. **Drop the input JSON** in `scripts/sdk_tester_matrix/inputs/`. It's automatically picked up.
+2. **Add an expectation file** in `scripts/sdk_tester_matrix/expectations/<your_input>.json`:
+   ```json
+   {
+     "tables_required": ["tester_my_table"],
+     "lob_columns_to_strip": [],
+     "assertions": [
+       {
+         "name": "tester_my_table has expected row count",
+         "sql": "SELECT 1 AS x FROM (SELECT COUNT(*) AS c FROM tester_my_table) t WHERE t.c <> 5"
+       }
+     ]
+   }
+   ```
+3. **Register it** in `scripts/sdk_tester_matrix/config.json` under `matrix.inputs`:
+   ```json
+   {
+     "name": "my_test",
+     "file": "my_input.json",
+     "expectations": "my_input.json"
+   }
+   ```
+4. **Re-run**: `python scripts/sdk_tester_matrix/run.py`. The matrix is now 5×3 = 15 combos.
+
+If the new test creates additional `tester_*` tables, append their names to `TESTER_TABLES_TO_DROP` in `run.py` (module constant near the top) so they get cleaned up between combos.
+
+## Editing expectations
+
+The expectation contract is **bad-rows count must be 0**:
+
+```json
+{
+  "name": "amount column updated correctly for all rows",
+  "sql": "SELECT 1 AS x FROM tester_transaction WHERE amount_renamed <> 202.57 OR amount_renamed IS NULL"
+}
+```
+
+The orchestrator wraps each `sql` as `SELECT COUNT(*) FROM (<your_sql>) bad_`. Author the SQL so it surfaces "bad" rows — anything that **should not be true**. Pass iff the wrapped query returns 0.
+
+**Contract notes:**
+
+- Every projection column needs an explicit name. Use `SELECT 1 AS x FROM …`, `SELECT id FROM …`, etc. Never bare `SELECT 1 FROM …` — Teradata error 3706: "All expressions in a derived table must have an explicit name".
+- Quote reserved/special column names. Teradata's `desc` is reserved → use `"desc"`.
+- For combos with a separate FastLoad variant (currently only `input`), set `fastload_expectations` in config and write a `<input>.fastload.json` reflecting the trimmed schema.
+
+## Troubleshooting
+
+| Symptom                                                                 | Likely cause / fix                                                                          |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `ERROR: connector not reachable on 127.0.0.1:50052`                     | The JAR isn't running. Start it in another terminal.                                        |
+| `ERROR: 'bteq' not on PATH`                                             | Install Teradata Tools and Utilities.                                                        |
+| `ERROR: 'docker' not on PATH`                                           | Install Docker Desktop / docker-ce.                                                          |
+| `ERROR: env var $TERADATA_PASSWORD not set`                             | Export the env vars first (see Quick Start).                                                 |
+| Combo passes the tester but fails validation                            | Open `<generated_dir>/bteq/<combo_id>__assert.log`. Look for `MATRIXASSERT_NNN <count>` rows; any count > 0 names a bad assertion. |
+| Combo fails with `Error 3614 / 2652`                                    | Previous run left temp tables in *Loading* state. Drop them in BTEQ or restart the JAR (clears Teradata sessions). |
+| All FastLoad combos fail with empty target tables                       | If you see this, check whether IDE-26074 fix is in your build. Pre-fix builds silently dropped FastLoad data when configured DB ≠ JDBC user home. |
+| `Error 5628 Column X not found` in assertions                           | The schema migration step didn't apply (likely because the upstream FastLoad write failed silently — see above). |
+
+## Bumping the docker tester version
+
+Edit `config.json` → `docker.tag` (currently `2.26.0410.001`). No code change.
+
+## FAQ
+
+**Q: Why does the JAR need to stay running across all 12 combos?**
+TMODE and `use.fastload` are read per-request from the gRPC `configurationMap`, not at JVM startup. So one JAR handles the whole matrix without restarts.
+
+**Q: Where does `configuration.json` live?**
+The orchestrator writes it to the docker bind-mount source (`docker.mount_source` in config — default `C:\Fivetran` on Windows). Each combo overwrites it. Archived copies live under `<generated_dir>/configurations/`.
+
+**Q: Why are inputs vendored in the repo instead of downloaded each run?**
+Reproducibility. Upstream changes to canonical SDK inputs would silently break the matrix. The vendored copies are the contract; bumping them is a deliberate commit.
+
+**Q: How do I re-run only the failing combos?**
+Use `--only <combo-id-csv>`. The combo IDs are in the report. E.g. `--only input__FastLoad,dml__FastLoad,sync_modes__FastLoad`.
+
+**Q: Can I run this in CI?**
+Yes — exit codes are CI-friendly (0 / 1 / 2). The run is hermetic *given* a Teradata host, env vars, and a running JAR. The orchestrator will need network access to the Docker registry and the Teradata host.

--- a/scripts/patch_tester_inputs.py
+++ b/scripts/patch_tester_inputs.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+Patch Fivetran SDK destination-connector-tester input JSONs to replace junk
+Java byte[].toString() values (e.g. "[B@7d4991ad") with valid base64.
+
+Workaround for an upstream defect in
+https://github.com/fivetran/fivetran_partner_sdk/blob/main/tools/destination-connector-tester/input-files/input.json
+where some binary_val fields contain "[B@<hex>" — the literal output of
+calling .toString() on a Java byte[] — instead of a base64-encoded payload.
+Java's Base64.getDecoder() rightly rejects these with
+"Illegal base64 character 5b" (0x5b is '[').
+
+Replacements are deterministic by occurrence order: the first junk value
+becomes base64 of "Row 1", the second "Row 2", etc. This matches the
+convention used in PR #29's manual patches so the existing validation SQL
+keeps decoding to the same expected byte sequences.
+
+Usage
+-----
+    # Print patched content to stdout (single file):
+    python scripts/patch_tester_inputs.py input.json
+
+    # Rewrite the file in place:
+    python scripts/patch_tester_inputs.py input.json --in-place
+
+    # Patch every JSON in a folder, in place:
+    python scripts/patch_tester_inputs.py /path/to/data/*.json --in-place
+
+    # Just count without writing:
+    python scripts/patch_tester_inputs.py input.json --dry-run
+
+Exit codes
+----------
+    0  — completed (with or without replacements)
+    1  — bad input (no files / file unreadable / multiple files without --in-place)
+
+Python 3.7+. Stdlib only.
+"""
+
+import sys
+if sys.version_info < (3, 7):
+    sys.stderr.write("ERROR: Python 3.7+ required; got {}.{}.\n".format(
+        sys.version_info.major, sys.version_info.minor))
+    sys.exit(1)
+
+import argparse
+import base64
+import json
+import re
+from pathlib import Path
+
+
+# Matches Java Object.toString() output for arrays. Examples:
+#   [B@7d4991ad           — byte[]
+#   [I@deadbeef           — int[]
+#   [[B@cafebabe          — byte[][]
+#   [Ljava.lang.String;@1 — String[]
+JAVA_ARRAY_TOSTRING = re.compile(r"^\[+(?:[BCDFIJSZ]|L[\w.$]+;)@[0-9a-f]+$")
+
+
+def encoded_row(n):
+    """Return base64('Row N') as an ASCII string."""
+    return base64.b64encode("Row {}".format(n).encode("ascii")).decode("ascii")
+
+
+def patch_value(value, counter):
+    """Recursively walk a JSON-decoded structure and replace junk values."""
+    if isinstance(value, dict):
+        return {k: patch_value(v, counter) for k, v in value.items()}
+    if isinstance(value, list):
+        return [patch_value(v, counter) for v in value]
+    if isinstance(value, str) and JAVA_ARRAY_TOSTRING.match(value):
+        counter[0] += 1
+        return encoded_row(counter[0])
+    return value
+
+
+def patch_file(path, in_place, dry_run, multi):
+    """Patch one file. Returns the count of replacements made (or 0)."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as e:
+        print("{}: cannot read ({})".format(path, e), file=sys.stderr)
+        return 0
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        print("{}: not valid JSON ({})".format(path, e), file=sys.stderr)
+        return 0
+
+    counter = [0]
+    patched = patch_value(data, counter)
+
+    if counter[0] == 0:
+        print("{}: no Java-array-toString junk found".format(path),
+              file=sys.stderr)
+        return 0
+
+    out = json.dumps(patched, indent=2)
+
+    if dry_run:
+        print("{}: would replace {} junk value(s)".format(path, counter[0]))
+        return counter[0]
+
+    if in_place:
+        path.write_text(out, encoding="utf-8")
+        print("{}: replaced {} junk value(s) (in-place)".format(path, counter[0]),
+              file=sys.stderr)
+    else:
+        if multi:
+            print("\n# === {} ===".format(path))
+        sys.stdout.write(out)
+        if not out.endswith("\n"):
+            sys.stdout.write("\n")
+    return counter[0]
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description="Patch Java byte[].toString() junk in Fivetran tester input JSONs."
+    )
+    p.add_argument("paths", nargs="+", help="JSON files to patch.")
+    p.add_argument(
+        "--in-place",
+        action="store_true",
+        help="Overwrite the source file with the patched content (recommended).",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report the count of replacements without writing anything.",
+    )
+    args = p.parse_args()
+
+    files = [Path(s) for s in args.paths]
+    missing = [f for f in files if not f.is_file()]
+    if missing:
+        for f in missing:
+            print("{}: not a file".format(f), file=sys.stderr)
+        sys.exit(1)
+
+    multi = len(files) > 1
+    if multi and not args.in_place and not args.dry_run:
+        print(
+            "ERROR: --in-place required when patching multiple files "
+            "(or use --dry-run).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    total = 0
+    for f in files:
+        total += patch_file(f, args.in_place, args.dry_run, multi)
+
+    print(
+        "Done. {} junk value(s) replaced across {} file(s).".format(total, len(files)),
+        file=sys.stderr,
+    )
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sdk_tester_matrix/README.md
+++ b/scripts/sdk_tester_matrix/README.md
@@ -36,9 +36,18 @@ so no JVM restart is needed.
    TERADATA_DATABASE   target database (BTEQ uses it for cleanup + assertions;
                        also passed to the connector so tables land in the same DB)
    ```
-6. **The 4 canonical input JSONs** placed at `C:\Fivetran\` (or whichever
-   `paths.canonical_inputs_dir` points to in `config.json`). Source:
-   <https://github.com/fivetran/fivetran_partner_sdk/tree/main/tools/destination-connector-tester/input-files>
+6. **Canonical input JSONs are vendored** in `scripts/sdk_tester_matrix/inputs/`
+   (4 files copied from
+   <https://github.com/fivetran/fivetran_partner_sdk/tree/main/tools/destination-connector-tester/input-files>).
+   No download step needed. Adding a new test case = drop a new JSON in that
+   folder + add an expectation file + add an entry to `matrix.inputs` in
+   `config.json`.
+
+   Note: `C:\Fivetran\` (the value of `docker.mount_source` in `config.json`)
+   is still used as the **docker bind-mount source** — patched copies of the
+   inputs and a per-combo `configuration.json` are written there at runtime
+   so the tester container reads them via its `/data` mount. The directory
+   is created automatically by the orchestrator.
 
 ## Usage
 

--- a/scripts/sdk_tester_matrix/README.md
+++ b/scripts/sdk_tester_matrix/README.md
@@ -130,6 +130,12 @@ The orchestrator wraps each `sql` as `SELECT COUNT(*) FROM (<sql>) bad_`,
 so the SQL just has to surface "bad" rows — anything that should not be
 true. Add new assertions by appending to the list.
 
+**Contract:** because the user SQL is wrapped in a derived table, every
+projection column needs an explicit name. Use `SELECT 1 AS x FROM …`,
+`SELECT id FROM …`, etc. — never bare `SELECT 1 FROM …` (Teradata
+error 3706: "All expressions in a derived table must have an explicit
+name").
+
 For combos with a separate FastLoad variant (currently only `input`), the
 orchestrator picks `fastload_expectations` from `config.json` when the
 combo's `fastload=true`. Set `lob_columns_to_strip` in the variant to have

--- a/scripts/sdk_tester_matrix/README.md
+++ b/scripts/sdk_tester_matrix/README.md
@@ -1,0 +1,151 @@
+# SDK Tester Matrix
+
+Single-click runner for the Fivetran SDK destination-connector-tester against
+this connector. Replaces the manual 12-step ritual of running each
+`(input × config)` combo by hand and spot-checking tables in BTEQ.
+
+## Matrix
+
+| Input file                                 | TMODE=ANSI | TMODE=TERA | use.fastload=true |
+| ------------------------------------------ | ---------- | ---------- | ----------------- |
+| `input.json`                               | ✓          | ✓          | ✓ (LOB-stripped)  |
+| `schema_migrations_input_ddl.json`         | ✓          | ✓          | ✓                 |
+| `schema_migrations_input_dml.json`         | ✓          | ✓          | ✓                 |
+| `schema_migrations_input_sync_modes.json`  | ✓          | ✓          | ✓                 |
+
+12 combos by default. The connector JAR stays running across all of them —
+TMODE and `use.fastload` are read per-request from the gRPC `configurationMap`,
+so no JVM restart is needed.
+
+## Prerequisites
+
+1. **Python 3.7+** (no third-party packages — stdlib only).
+2. **`bteq`** on PATH (Teradata Tools and Utilities).
+3. **`docker`** on PATH (Docker Desktop on Windows, docker-ce on Linux).
+4. **Connector JAR running** on port 50052, in another terminal:
+   ```
+   java -jar build/libs/TeradataDestination.jar
+   ```
+5. **Env vars** for the Teradata connection (nothing sensitive in `config.json`):
+   ```
+   TD_HOST       Teradata host (IP or DNS, optionally :port)
+   TD_USER       Teradata username
+   TD_PASSWORD   Teradata password
+   TD_DATABASE   target database name (used by BTEQ for cleanup + assertions)
+   ```
+6. **The 4 canonical input JSONs** placed at `C:\Fivetran\` (or whichever
+   `paths.canonical_inputs_dir` points to in `config.json`). Source:
+   <https://github.com/fivetran/fivetran_partner_sdk/tree/main/tools/destination-connector-tester/input-files>
+
+## Usage
+
+```bash
+# Run the full 12-combo matrix
+python scripts/sdk_tester_matrix/run.py
+
+# Run a subset (combo IDs are <input_name>__<config_id>)
+python scripts/sdk_tester_matrix/run.py --only input__FastLoad,dml__TERA
+
+# Stop on the first failure (default: keep going to give a complete view)
+python scripts/sdk_tester_matrix/run.py --fail-fast
+
+# Print the planned combos and exit (useful for sanity-checking config)
+python scripts/sdk_tester_matrix/run.py --dry-run
+
+# Delete the generated/ dir on a fully-passing run
+python scripts/sdk_tester_matrix/run.py --purge-generated
+
+# Custom config
+python scripts/sdk_tester_matrix/run.py --config /path/to/my-config.json
+```
+
+### Exit codes
+
+| Code | Meaning                                                                |
+| ---- | ---------------------------------------------------------------------- |
+| 0    | Every combo passed (tester rc=0 + every assertion's bad-rows count is 0) |
+| 1    | At least one combo failed validation or the tester                     |
+| 2    | Orchestrator fault: bad config, missing env var, missing CLI tool, connector port unreachable, or BTEQ logon failure |
+
+## What a run does
+
+For each combo (in order):
+
+1. **Probe** `127.0.0.1:50052` — hard-fails fast if the JAR isn't up.
+2. **Drop** the 10 known `tester_*` tables (idempotent; "doesn't exist" is silent).
+3. **Write** `<canonical_inputs_dir>/configuration.json` with this combo's
+   `tmode`, `use.fastload`, and the connection settings from env vars. The
+   tester reads this file and forwards its contents as the gRPC
+   `configurationMap`. An archive copy is kept under
+   `<generated_dir>/configurations/<combo_id>.json`.
+4. **Patch the input JSON**:
+   - Auto-fix any upstream `[B@xxx` byte[].toString() junk
+     (reuses `scripts/patch_tester_inputs.py`).
+   - For `input.json × FastLoad` only: strip BLOB/JSON/XML columns
+     (workaround for the parked Jira on FastLoad pre-flight LOB validation).
+   - Write the patched copy to `<canonical_inputs_dir>/<combo_id>.json` so
+     the docker bind mount can see it.
+5. **Run** the SDK tester docker container, streaming logs to stderr and to
+   `<generated_dir>/tester-logs/<combo_id>.log`.
+6. **Validate** by running the combo's expectation file (`expectations/<input>.json`
+   or `expectations/<input>.fastload.json`) as one BTEQ script. Each assertion
+   is wrapped as `SELECT COUNT(*) FROM (<your_sql>) AS bad` — pass iff count
+   is 0. The orchestrator parses tagged result rows.
+7. **Record** the combo result.
+
+After all combos finish, prints a console matrix and writes
+`<generated_dir>/results.json`.
+
+## Generated artifacts
+
+```
+<generated_dir>/
+├── configurations/<combo_id>.json    # archive of configuration.json used
+├── inputs/<combo_id>.json            # patched input handed to docker
+├── tester-logs/<combo_id>.log        # captured tester stdout+stderr
+├── bteq/<combo_id>__drop.sql/log     # cleanup
+├── bteq/<combo_id>__assert.sql/log   # validation
+└── results.json                      # final report
+```
+
+These are kept by default (post-mortem useful). Use `--purge-generated` to
+delete on a fully-passing run.
+
+## Editing expectations
+
+Each `expectations/<input>.json` is a list of assertions. The uniform
+contract is **bad-rows count must be 0**:
+
+```json
+{
+  "name": "tester_transaction has 6 rows",
+  "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM tester_transaction) t WHERE t.c <> 6"
+}
+```
+
+The orchestrator wraps each `sql` as `SELECT COUNT(*) FROM (<sql>) bad_`,
+so the SQL just has to surface "bad" rows — anything that should not be
+true. Add new assertions by appending to the list.
+
+For combos with a separate FastLoad variant (currently only `input`), the
+orchestrator picks `fastload_expectations` from `config.json` when the
+combo's `fastload=true`. Set `lob_columns_to_strip` in the variant to have
+the orchestrator strip those columns from the input JSON before docker.
+
+## Troubleshooting
+
+- **`ERROR: connector not reachable on 127.0.0.1:50052`** — the JAR isn't
+  running. Start it in another terminal.
+- **`ERROR: 'bteq' not on PATH`** — install Teradata Tools and Utilities.
+- **`ERROR: 'docker' not on PATH`** — install Docker Desktop / docker-ce.
+- **`ERROR: env var $TD_PASSWORD not set`** — export the env vars first.
+- **Combo passes the tester but fails validation** — open
+  `<generated_dir>/bteq/<combo_id>__assert.log`. Look for the
+  `MATRIXASSERT_NNN <count>` rows; any count > 0 names a bad assertion.
+- **Combo fails with `Error 3614 / 2652`** — the previous tester run left
+  temp tables in *Loading* state. Drop them manually in BTEQ or restart
+  the connector JAR (clears the Teradata sessions).
+
+## Bumping the docker tester version
+
+Edit `config.json` → `docker.tag` (currently `2.26.0410.001`). No code change.

--- a/scripts/sdk_tester_matrix/README.md
+++ b/scripts/sdk_tester_matrix/README.md
@@ -26,12 +26,15 @@ so no JVM restart is needed.
    ```
    java -jar build/libs/TeradataDestination.jar
    ```
-5. **Env vars** for the Teradata connection (nothing sensitive in `config.json`):
+5. **Env vars** for the Teradata connection (nothing sensitive in `config.json`).
+   These match the names `IntegrationTestBase` already uses, so the same
+   environment that runs `gradle test` runs this:
    ```
-   TD_HOST       Teradata host (IP or DNS, optionally :port)
-   TD_USER       Teradata username
-   TD_PASSWORD   Teradata password
-   TD_DATABASE   target database name (used by BTEQ for cleanup + assertions)
+   TERADATA_HOST       Teradata host (IP or DNS, optionally :port)
+   TERADATA_USER       Teradata username
+   TERADATA_PASSWORD   Teradata password
+   TERADATA_DATABASE   target database (BTEQ uses it for cleanup + assertions;
+                       also passed to the connector so tables land in the same DB)
    ```
 6. **The 4 canonical input JSONs** placed at `C:\Fivetran\` (or whichever
    `paths.canonical_inputs_dir` points to in `config.json`). Source:
@@ -138,7 +141,7 @@ the orchestrator strip those columns from the input JSON before docker.
   running. Start it in another terminal.
 - **`ERROR: 'bteq' not on PATH`** — install Teradata Tools and Utilities.
 - **`ERROR: 'docker' not on PATH`** — install Docker Desktop / docker-ce.
-- **`ERROR: env var $TD_PASSWORD not set`** — export the env vars first.
+- **`ERROR: env var $TERADATA_PASSWORD not set`** — export the env vars first.
 - **Combo passes the tester but fails validation** — open
   `<generated_dir>/bteq/<combo_id>__assert.log`. Look for the
   `MATRIXASSERT_NNN <count>` rows; any count > 0 names a bad assertion.

--- a/scripts/sdk_tester_matrix/config.json
+++ b/scripts/sdk_tester_matrix/config.json
@@ -1,0 +1,66 @@
+{
+  "teradata": {
+    "host_env": "TD_HOST",
+    "user_env": "TD_USER",
+    "password_env": "TD_PASSWORD",
+    "database_env": "TD_DATABASE"
+  },
+  "connector": {
+    "host": "host.docker.internal",
+    "port": 50052
+  },
+  "docker": {
+    "image": "us-docker.pkg.dev/build-286712/public-docker-us/sdktesters-v2/sdk-tester",
+    "tag": "2.26.0410.001",
+    "memory": "12g",
+    "java_tool_options": "-Xmx8g -Xms1g",
+    "mount_source": "C:\\Fivetran",
+    "mount_target": "/data",
+    "working_dir_env": "C:\\Fivetran",
+    "network": "host",
+    "extra_args": ["--disable-operation-delay"]
+  },
+  "paths": {
+    "canonical_inputs_dir": "C:\\Fivetran",
+    "generated_dir": "C:\\Fivetran\\generated",
+    "expectations_dir": "scripts/sdk_tester_matrix/expectations"
+  },
+  "matrix": {
+    "inputs": [
+      {
+        "name": "input",
+        "file": "input.json",
+        "expectations": "input.json",
+        "fastload_expectations": "input.fastload.json"
+      },
+      {
+        "name": "ddl",
+        "file": "schema_migrations_input_ddl.json",
+        "expectations": "schema_migrations_input_ddl.json"
+      },
+      {
+        "name": "dml",
+        "file": "schema_migrations_input_dml.json",
+        "expectations": "schema_migrations_input_dml.json"
+      },
+      {
+        "name": "sync_modes",
+        "file": "schema_migrations_input_sync_modes.json",
+        "expectations": "schema_migrations_input_sync_modes.json"
+      }
+    ],
+    "configs": [
+      {"id": "ANSI",     "tmode": "ANSI", "fastload": false},
+      {"id": "TERA",     "tmode": "TERA", "fastload": false},
+      {"id": "FastLoad", "tmode": "TERA", "fastload": true}
+    ]
+  },
+  "configuration_template": {
+    "default.varchar.size": "1000",
+    "varchar.character.set": "LATIN",
+    "batch.size": "100000",
+    "query.band": "",
+    "logmech": "TD2",
+    "ssl.mode": "DISABLE"
+  }
+}

--- a/scripts/sdk_tester_matrix/config.json
+++ b/scripts/sdk_tester_matrix/config.json
@@ -21,7 +21,7 @@
     "extra_args": ["--disable-operation-delay"]
   },
   "paths": {
-    "canonical_inputs_dir": "C:\\Fivetran",
+    "canonical_inputs_dir": "scripts/sdk_tester_matrix/inputs",
     "generated_dir": "C:\\Fivetran\\generated",
     "expectations_dir": "scripts/sdk_tester_matrix/expectations"
   },

--- a/scripts/sdk_tester_matrix/config.json
+++ b/scripts/sdk_tester_matrix/config.json
@@ -1,9 +1,9 @@
 {
   "teradata": {
-    "host_env": "TD_HOST",
-    "user_env": "TD_USER",
-    "password_env": "TD_PASSWORD",
-    "database_env": "TD_DATABASE"
+    "host_env": "TERADATA_HOST",
+    "user_env": "TERADATA_USER",
+    "password_env": "TERADATA_PASSWORD",
+    "database_env": "TERADATA_DATABASE"
   },
   "connector": {
     "host": "host.docker.internal",

--- a/scripts/sdk_tester_matrix/expectations/input.fastload.json
+++ b/scripts/sdk_tester_matrix/expectations/input.fastload.json
@@ -1,0 +1,31 @@
+{
+  "_comment": "input.json under use.fastload=true with the LOB-strip workaround applied. Teradata FastLoad CSV does NOT support BLOB/JSON/XML — see the parked Jira for FastLoad pre-flight LOB validation. Strip those columns before handing the input to docker, and mirror the trimmed schema in the assertions.",
+  "tables_required": [
+    "tester_transaction",
+    "tester_campaign",
+    "tester_composite_table"
+  ],
+  "lob_columns_to_strip": ["binary_val", "json_val", "xml_val"],
+  "assertions": [
+    {
+      "name": "tester_transaction exists with at least one row",
+      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM tester_transaction) t WHERE t.c < 1"
+    },
+    {
+      "name": "tester_campaign exists with at least one row",
+      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM tester_campaign) t WHERE t.c < 1"
+    },
+    {
+      "name": "tester_composite_table exists with at least one row",
+      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM tester_composite_table) t WHERE t.c < 1"
+    },
+    {
+      "name": "all tester_transaction rows have _fivetran_synced populated",
+      "sql": "SELECT 1 FROM tester_transaction WHERE _fivetran_synced IS NULL"
+    },
+    {
+      "name": "no LOB columns leaked into tester_transaction (FastLoad strip workaround)",
+      "sql": "SELECT 1 FROM dbc.columnsv WHERE databasename = DATABASE AND tablename = 'tester_transaction' AND columnname IN ('binary_val','json_val','xml_val')"
+    }
+  ]
+}

--- a/scripts/sdk_tester_matrix/expectations/input.fastload.json
+++ b/scripts/sdk_tester_matrix/expectations/input.fastload.json
@@ -9,23 +9,23 @@
   "assertions": [
     {
       "name": "tester_transaction exists with at least one row",
-      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM tester_transaction) t WHERE t.c < 1"
+      "sql": "SELECT 1 AS x FROM (SELECT COUNT(*) AS c FROM tester_transaction) t WHERE t.c < 1"
     },
     {
       "name": "tester_campaign exists with at least one row",
-      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM tester_campaign) t WHERE t.c < 1"
+      "sql": "SELECT 1 AS x FROM (SELECT COUNT(*) AS c FROM tester_campaign) t WHERE t.c < 1"
     },
     {
       "name": "tester_composite_table exists with at least one row",
-      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM tester_composite_table) t WHERE t.c < 1"
+      "sql": "SELECT 1 AS x FROM (SELECT COUNT(*) AS c FROM tester_composite_table) t WHERE t.c < 1"
     },
     {
       "name": "all tester_transaction rows have _fivetran_synced populated",
-      "sql": "SELECT 1 FROM tester_transaction WHERE _fivetran_synced IS NULL"
+      "sql": "SELECT 1 AS x FROM tester_transaction WHERE _fivetran_synced IS NULL"
     },
     {
       "name": "no LOB columns leaked into tester_transaction (FastLoad strip workaround)",
-      "sql": "SELECT 1 FROM dbc.columnsv WHERE databasename = DATABASE AND tablename = 'tester_transaction' AND columnname IN ('binary_val','json_val','xml_val')"
+      "sql": "SELECT 1 AS x FROM dbc.columnsv WHERE databasename = DATABASE AND tablename = 'tester_transaction' AND columnname IN ('binary_val','json_val','xml_val')"
     }
   ]
 }

--- a/scripts/sdk_tester_matrix/expectations/input.json
+++ b/scripts/sdk_tester_matrix/expectations/input.json
@@ -9,23 +9,23 @@
   "assertions": [
     {
       "name": "tester_transaction exists with at least one row",
-      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM tester_transaction) t WHERE t.c < 1"
+      "sql": "SELECT 1 AS x FROM (SELECT COUNT(*) AS c FROM tester_transaction) t WHERE t.c < 1"
     },
     {
       "name": "tester_campaign exists with at least one row",
-      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM tester_campaign) t WHERE t.c < 1"
+      "sql": "SELECT 1 AS x FROM (SELECT COUNT(*) AS c FROM tester_campaign) t WHERE t.c < 1"
     },
     {
       "name": "tester_composite_table exists with at least one row",
-      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM tester_composite_table) t WHERE t.c < 1"
+      "sql": "SELECT 1 AS x FROM (SELECT COUNT(*) AS c FROM tester_composite_table) t WHERE t.c < 1"
     },
     {
       "name": "no tester_transaction rows have _fivetran_deleted=1 (deleted rows must be hard-deleted unless soft-delete mode)",
-      "sql": "SELECT 1 FROM tester_transaction WHERE _fivetran_deleted = 1 AND id NOT IN (SELECT id FROM tester_transaction WHERE _fivetran_deleted = 0)"
+      "sql": "SELECT 1 AS x FROM tester_transaction WHERE _fivetran_deleted = 1 AND id NOT IN (SELECT id FROM tester_transaction WHERE _fivetran_deleted = 0)"
     },
     {
       "name": "all tester_transaction rows have _fivetran_synced populated",
-      "sql": "SELECT 1 FROM tester_transaction WHERE _fivetran_synced IS NULL"
+      "sql": "SELECT 1 AS x FROM tester_transaction WHERE _fivetran_synced IS NULL"
     }
   ]
 }

--- a/scripts/sdk_tester_matrix/expectations/input.json
+++ b/scripts/sdk_tester_matrix/expectations/input.json
@@ -1,0 +1,31 @@
+{
+  "_comment": "Expectations after running input.json under TMODE=ANSI or TMODE=TERA. Each assertion's bad-rows count must be 0. Conservative: focuses on tables existing and core invariants. Tighten as the canonical input.json's exact post-state stabilises.",
+  "tables_required": [
+    "tester_transaction",
+    "tester_campaign",
+    "tester_composite_table"
+  ],
+  "lob_columns_to_strip": [],
+  "assertions": [
+    {
+      "name": "tester_transaction exists with at least one row",
+      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM tester_transaction) t WHERE t.c < 1"
+    },
+    {
+      "name": "tester_campaign exists with at least one row",
+      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM tester_campaign) t WHERE t.c < 1"
+    },
+    {
+      "name": "tester_composite_table exists with at least one row",
+      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM tester_composite_table) t WHERE t.c < 1"
+    },
+    {
+      "name": "no tester_transaction rows have _fivetran_deleted=1 (deleted rows must be hard-deleted unless soft-delete mode)",
+      "sql": "SELECT 1 FROM tester_transaction WHERE _fivetran_deleted = 1 AND id NOT IN (SELECT id FROM tester_transaction WHERE _fivetran_deleted = 0)"
+    },
+    {
+      "name": "all tester_transaction rows have _fivetran_synced populated",
+      "sql": "SELECT 1 FROM tester_transaction WHERE _fivetran_synced IS NULL"
+    }
+  ]
+}

--- a/scripts/sdk_tester_matrix/expectations/input.json
+++ b/scripts/sdk_tester_matrix/expectations/input.json
@@ -20,8 +20,8 @@
       "sql": "SELECT 1 AS x FROM (SELECT COUNT(*) AS c FROM tester_composite_table) t WHERE t.c < 1"
     },
     {
-      "name": "no tester_transaction rows have _fivetran_deleted=1 (deleted rows must be hard-deleted unless soft-delete mode)",
-      "sql": "SELECT 1 AS x FROM tester_transaction WHERE _fivetran_deleted = 1 AND id NOT IN (SELECT id FROM tester_transaction WHERE _fivetran_deleted = 0)"
+      "name": "tester_transaction is in history mode (has _fivetran_active column)",
+      "sql": "SELECT 1 AS x FROM (SELECT COUNT(*) AS c FROM dbc.columnsv WHERE databasename = DATABASE AND tablename = 'tester_transaction' AND columnname = '_fivetran_active') t WHERE t.c <> 1"
     },
     {
       "name": "all tester_transaction rows have _fivetran_synced populated",

--- a/scripts/sdk_tester_matrix/expectations/schema_migrations_input_ddl.json
+++ b/scripts/sdk_tester_matrix/expectations/schema_migrations_input_ddl.json
@@ -1,0 +1,26 @@
+{
+  "_comment": "Expectations after schema_migrations_input_ddl.json — exercises AddColumn / AlterColumn / ChangeColumnType against tester_transaction and tester_composite_table.",
+  "tables_required": [
+    "tester_transaction",
+    "tester_composite_table"
+  ],
+  "lob_columns_to_strip": [],
+  "assertions": [
+    {
+      "name": "tester_transaction exists",
+      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM dbc.tablesv WHERE databasename = DATABASE AND tablename = 'tester_transaction') t WHERE t.c <> 1"
+    },
+    {
+      "name": "tester_composite_table exists",
+      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM dbc.tablesv WHERE databasename = DATABASE AND tablename = 'tester_composite_table') t WHERE t.c <> 1"
+    },
+    {
+      "name": "tester_transaction has the AddColumn DDL-added column",
+      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM dbc.columnsv WHERE databasename = DATABASE AND tablename = 'tester_transaction' AND columnname = 'col_added') t WHERE t.c <> 1"
+    },
+    {
+      "name": "no orphan _alter_tmp tables remain after DDL migrations",
+      "sql": "SELECT 1 FROM dbc.tablesv WHERE databasename = DATABASE AND tablename IN ('tester_transaction_alter_tmp','tester_composite_table_alter_tmp')"
+    }
+  ]
+}

--- a/scripts/sdk_tester_matrix/expectations/schema_migrations_input_ddl.json
+++ b/scripts/sdk_tester_matrix/expectations/schema_migrations_input_ddl.json
@@ -5,23 +5,23 @@
   "assertions": [
     {
       "name": "tester_transaction exists",
-      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM dbc.tablesv WHERE databasename = DATABASE AND tablename = 'tester_transaction') t WHERE t.c <> 1"
+      "sql": "SELECT 1 AS x FROM (SELECT COUNT(*) AS c FROM dbc.tablesv WHERE databasename = DATABASE AND tablename = 'tester_transaction') t WHERE t.c <> 1"
     },
     {
       "name": "tester_transaction has operation_time column (AddColumn)",
-      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM dbc.columnsv WHERE databasename = DATABASE AND tablename = 'tester_transaction' AND columnname = 'operation_time') t WHERE t.c <> 1"
+      "sql": "SELECT 1 AS x FROM (SELECT COUNT(*) AS c FROM dbc.columnsv WHERE databasename = DATABASE AND tablename = 'tester_transaction' AND columnname = 'operation_time') t WHERE t.c <> 1"
     },
     {
       "name": "tester_transaction has amount column (ChangeColumnDataType target)",
-      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM dbc.columnsv WHERE databasename = DATABASE AND tablename = 'tester_transaction' AND columnname = 'amount') t WHERE t.c <> 1"
+      "sql": "SELECT 1 AS x FROM (SELECT COUNT(*) AS c FROM dbc.columnsv WHERE databasename = DATABASE AND tablename = 'tester_transaction' AND columnname = 'amount') t WHERE t.c <> 1"
     },
     {
       "name": "tester_transaction does NOT have desc column (DropColumn)",
-      "sql": "SELECT 1 FROM dbc.columnsv WHERE databasename = DATABASE AND tablename = 'tester_transaction' AND columnname = 'desc'"
+      "sql": "SELECT 1 AS x FROM dbc.columnsv WHERE databasename = DATABASE AND tablename = 'tester_transaction' AND columnname = 'desc'"
     },
     {
       "name": "no orphan _alter_tmp tables remain after DDL migrations",
-      "sql": "SELECT 1 FROM dbc.tablesv WHERE databasename = DATABASE AND tablename IN ('tester_transaction_alter_tmp', 'tester_composite_table_alter_tmp')"
+      "sql": "SELECT 1 AS x FROM dbc.tablesv WHERE databasename = DATABASE AND tablename IN ('tester_transaction_alter_tmp', 'tester_composite_table_alter_tmp')"
     }
   ]
 }

--- a/scripts/sdk_tester_matrix/expectations/schema_migrations_input_ddl.json
+++ b/scripts/sdk_tester_matrix/expectations/schema_migrations_input_ddl.json
@@ -1,9 +1,6 @@
 {
-  "_comment": "Expectations after schema_migrations_input_ddl.json — exercises AddColumn / AlterColumn / ChangeColumnType against tester_transaction and tester_composite_table.",
-  "tables_required": [
-    "tester_transaction",
-    "tester_composite_table"
-  ],
+  "_comment": "After schema_migrations_input_ddl.json: only the 'transaction' table is created (no composite_table). schema_migration ops are AddColumn(operation_time UTC_DATETIME), ChangeColumnDataType(amount FLOAT->FLOAT), DropColumn(desc). End state per the canonical ddl input + the 2026-05-06 run log: tester_transaction has operation_time, has amount, does NOT have desc.",
+  "tables_required": ["tester_transaction"],
   "lob_columns_to_strip": [],
   "assertions": [
     {
@@ -11,16 +8,20 @@
       "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM dbc.tablesv WHERE databasename = DATABASE AND tablename = 'tester_transaction') t WHERE t.c <> 1"
     },
     {
-      "name": "tester_composite_table exists",
-      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM dbc.tablesv WHERE databasename = DATABASE AND tablename = 'tester_composite_table') t WHERE t.c <> 1"
+      "name": "tester_transaction has operation_time column (AddColumn)",
+      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM dbc.columnsv WHERE databasename = DATABASE AND tablename = 'tester_transaction' AND columnname = 'operation_time') t WHERE t.c <> 1"
     },
     {
-      "name": "tester_transaction has the AddColumn DDL-added column",
-      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM dbc.columnsv WHERE databasename = DATABASE AND tablename = 'tester_transaction' AND columnname = 'col_added') t WHERE t.c <> 1"
+      "name": "tester_transaction has amount column (ChangeColumnDataType target)",
+      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM dbc.columnsv WHERE databasename = DATABASE AND tablename = 'tester_transaction' AND columnname = 'amount') t WHERE t.c <> 1"
+    },
+    {
+      "name": "tester_transaction does NOT have desc column (DropColumn)",
+      "sql": "SELECT 1 FROM dbc.columnsv WHERE databasename = DATABASE AND tablename = 'tester_transaction' AND columnname = 'desc'"
     },
     {
       "name": "no orphan _alter_tmp tables remain after DDL migrations",
-      "sql": "SELECT 1 FROM dbc.tablesv WHERE databasename = DATABASE AND tablename IN ('tester_transaction_alter_tmp','tester_composite_table_alter_tmp')"
+      "sql": "SELECT 1 FROM dbc.tablesv WHERE databasename = DATABASE AND tablename IN ('tester_transaction_alter_tmp', 'tester_composite_table_alter_tmp')"
     }
   ]
 }

--- a/scripts/sdk_tester_matrix/expectations/schema_migrations_input_dml.json
+++ b/scripts/sdk_tester_matrix/expectations/schema_migrations_input_dml.json
@@ -8,39 +8,39 @@
   "assertions": [
     {
       "name": "tester_transaction has exactly 6 rows",
-      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM tester_transaction) t WHERE t.c <> 6"
+      "sql": "SELECT 1 AS x FROM (SELECT COUNT(*) AS c FROM tester_transaction) t WHERE t.c <> 6"
     },
     {
       "name": "every tester_transaction row has amount_renamed = 202.57 (UpdateColumnValue)",
-      "sql": "SELECT 1 FROM tester_transaction WHERE amount_renamed <> 202.57 OR amount_renamed IS NULL"
+      "sql": "SELECT 1 AS x FROM tester_transaction WHERE amount_renamed <> 202.57 OR amount_renamed IS NULL"
     },
     {
       "name": "every tester_transaction row has desc = NULL (SetColumnToNull)",
-      "sql": "SELECT 1 FROM tester_transaction WHERE \"desc\" IS NOT NULL"
+      "sql": "SELECT 1 AS x FROM tester_transaction WHERE \"desc\" IS NOT NULL"
     },
     {
       "name": "every tester_transaction row has operation_time = 2005-05-28 20:57:00 (AddColumnWithDefaultValue)",
-      "sql": "SELECT 1 FROM tester_transaction WHERE operation_time <> TIMESTAMP '2005-05-28 20:57:00'"
+      "sql": "SELECT 1 AS x FROM tester_transaction WHERE operation_time <> TIMESTAMP '2005-05-28 20:57:00'"
     },
     {
       "name": "tester_transaction_renamed exists (RenameTable)",
-      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM dbc.tablesv WHERE databasename = DATABASE AND tablename = 'tester_transaction_renamed') t WHERE t.c <> 1"
+      "sql": "SELECT 1 AS x FROM (SELECT COUNT(*) AS c FROM dbc.tablesv WHERE databasename = DATABASE AND tablename = 'tester_transaction_renamed') t WHERE t.c <> 1"
     },
     {
       "name": "tester_transaction_drop is dropped (DropTable)",
-      "sql": "SELECT 1 FROM dbc.tablesv WHERE databasename = DATABASE AND tablename = 'tester_transaction_drop'"
+      "sql": "SELECT 1 AS x FROM dbc.tablesv WHERE databasename = DATABASE AND tablename = 'tester_transaction_drop'"
     },
     {
       "name": "tester_transaction_new is dropped (was renamed away)",
-      "sql": "SELECT 1 FROM dbc.tablesv WHERE databasename = DATABASE AND tablename = 'tester_transaction_new'"
+      "sql": "SELECT 1 AS x FROM dbc.tablesv WHERE databasename = DATABASE AND tablename = 'tester_transaction_new'"
     },
     {
       "name": "desc_detailed preserved original desc values via CopyColumn (id=10 -> 'three')",
-      "sql": "SELECT 1 FROM tester_transaction WHERE id = 10 AND desc_detailed <> 'three'"
+      "sql": "SELECT 1 AS x FROM tester_transaction WHERE id = 10 AND desc_detailed <> 'three'"
     },
     {
       "name": "desc_detailed preserved original desc values via CopyColumn (id=20 -> 'money')",
-      "sql": "SELECT 1 FROM tester_transaction WHERE id = 20 AND desc_detailed <> 'money'"
+      "sql": "SELECT 1 AS x FROM tester_transaction WHERE id = 20 AND desc_detailed <> 'money'"
     }
   ]
 }

--- a/scripts/sdk_tester_matrix/expectations/schema_migrations_input_dml.json
+++ b/scripts/sdk_tester_matrix/expectations/schema_migrations_input_dml.json
@@ -1,0 +1,46 @@
+{
+  "_comment": "Expectations after schema_migrations_input_dml.json. From manual session: 8 DML migrations on tester_transaction — CopyColumn(desc->desc_detailed), UpdateColumnValue(amount=202.57), AddColumnWithDefaultValue(operation_time=2005-05-28T20:57:00Z), SetColumnToNull(desc), CopyTable(transaction->transaction_new), RenameColumn(amount->amount_renamed), RenameTable(transaction_new->transaction_renamed), DropTable(transaction_drop). End state: tester_transaction has 6 rows with amount_renamed=202.57, desc=NULL, desc_detailed populated; tester_transaction_renamed exists; tester_transaction_drop and tester_transaction_new are gone.",
+  "tables_required": [
+    "tester_transaction",
+    "tester_transaction_renamed"
+  ],
+  "lob_columns_to_strip": [],
+  "assertions": [
+    {
+      "name": "tester_transaction has exactly 6 rows",
+      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM tester_transaction) t WHERE t.c <> 6"
+    },
+    {
+      "name": "every tester_transaction row has amount_renamed = 202.57 (UpdateColumnValue)",
+      "sql": "SELECT 1 FROM tester_transaction WHERE amount_renamed <> 202.57 OR amount_renamed IS NULL"
+    },
+    {
+      "name": "every tester_transaction row has desc = NULL (SetColumnToNull)",
+      "sql": "SELECT 1 FROM tester_transaction WHERE \"desc\" IS NOT NULL"
+    },
+    {
+      "name": "every tester_transaction row has operation_time = 2005-05-28 20:57:00 (AddColumnWithDefaultValue)",
+      "sql": "SELECT 1 FROM tester_transaction WHERE operation_time <> TIMESTAMP '2005-05-28 20:57:00'"
+    },
+    {
+      "name": "tester_transaction_renamed exists (RenameTable)",
+      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM dbc.tablesv WHERE databasename = DATABASE AND tablename = 'tester_transaction_renamed') t WHERE t.c <> 1"
+    },
+    {
+      "name": "tester_transaction_drop is dropped (DropTable)",
+      "sql": "SELECT 1 FROM dbc.tablesv WHERE databasename = DATABASE AND tablename = 'tester_transaction_drop'"
+    },
+    {
+      "name": "tester_transaction_new is dropped (was renamed away)",
+      "sql": "SELECT 1 FROM dbc.tablesv WHERE databasename = DATABASE AND tablename = 'tester_transaction_new'"
+    },
+    {
+      "name": "desc_detailed preserved original desc values via CopyColumn (id=10 -> 'three')",
+      "sql": "SELECT 1 FROM tester_transaction WHERE id = 10 AND desc_detailed <> 'three'"
+    },
+    {
+      "name": "desc_detailed preserved original desc values via CopyColumn (id=20 -> 'money')",
+      "sql": "SELECT 1 FROM tester_transaction WHERE id = 20 AND desc_detailed <> 'money'"
+    }
+  ]
+}

--- a/scripts/sdk_tester_matrix/expectations/schema_migrations_input_sync_modes.json
+++ b/scripts/sdk_tester_matrix/expectations/schema_migrations_input_sync_modes.json
@@ -9,51 +9,51 @@
   "assertions": [
     {
       "name": "tester_transaction has 6 rows after MigrateSoftDeleteToHistory",
-      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM tester_transaction) t WHERE t.c <> 6"
+      "sql": "SELECT 1 AS x FROM (SELECT COUNT(*) AS c FROM tester_transaction) t WHERE t.c <> 6"
     },
     {
       "name": "tester_transaction was migrated to history mode (has _fivetran_active column)",
-      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM dbc.columnsv WHERE databasename = DATABASE AND tablename = 'tester_transaction' AND columnname = '_fivetran_active') t WHERE t.c <> 1"
+      "sql": "SELECT 1 AS x FROM (SELECT COUNT(*) AS c FROM dbc.columnsv WHERE databasename = DATABASE AND tablename = 'tester_transaction' AND columnname = '_fivetran_active') t WHERE t.c <> 1"
     },
     {
       "name": "tester_transaction has no _fivetran_deleted column anymore (history mode)",
-      "sql": "SELECT 1 FROM dbc.columnsv WHERE databasename = DATABASE AND tablename = 'tester_transaction' AND columnname = '_fivetran_deleted'"
+      "sql": "SELECT 1 AS x FROM dbc.columnsv WHERE databasename = DATABASE AND tablename = 'tester_transaction' AND columnname = '_fivetran_deleted'"
     },
     {
       "name": "all tester_transaction rows are active (_fivetran_active=1)",
-      "sql": "SELECT 1 FROM tester_transaction WHERE _fivetran_active <> 1"
+      "sql": "SELECT 1 AS x FROM tester_transaction WHERE _fivetran_active <> 1"
     },
     {
       "name": "tester_transaction_history has 13 rows (6 base + AddColumn versioning + DropColumn versioning)",
-      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM tester_transaction_history) t WHERE t.c <> 13"
+      "sql": "SELECT 1 AS x FROM (SELECT COUNT(*) AS c FROM tester_transaction_history) t WHERE t.c <> 13"
     },
     {
       "name": "tester_transaction_history has the article column (AddColumnInHistoryMode)",
-      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM dbc.columnsv WHERE databasename = DATABASE AND tablename = 'tester_transaction_history' AND columnname = 'article') t WHERE t.c <> 1"
+      "sql": "SELECT 1 AS x FROM (SELECT COUNT(*) AS c FROM dbc.columnsv WHERE databasename = DATABASE AND tablename = 'tester_transaction_history' AND columnname = 'article') t WHERE t.c <> 1"
     },
     {
       "name": "active tester_transaction_history rows have article = 'Ordered article'",
-      "sql": "SELECT 1 FROM tester_transaction_history WHERE _fivetran_active = 1 AND (article IS NULL OR article <> 'Ordered article')"
+      "sql": "SELECT 1 AS x FROM tester_transaction_history WHERE _fivetran_active = 1 AND (article IS NULL OR article <> 'Ordered article')"
     },
     {
       "name": "active tester_transaction_history rows have desc = NULL (DropColumnInHistoryMode soft-drop)",
-      "sql": "SELECT 1 FROM tester_transaction_history WHERE _fivetran_active = 1 AND \"desc\" IS NOT NULL"
+      "sql": "SELECT 1 AS x FROM tester_transaction_history WHERE _fivetran_active = 1 AND \"desc\" IS NOT NULL"
     },
     {
       "name": "tester_new_transaction_history has 6 rows after MigrateHistoryToSoftDelete",
-      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM tester_new_transaction_history) t WHERE t.c <> 6"
+      "sql": "SELECT 1 AS x FROM (SELECT COUNT(*) AS c FROM tester_new_transaction_history) t WHERE t.c <> 6"
     },
     {
       "name": "tester_new_transaction_history has _fivetran_deleted column (soft-delete mode)",
-      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM dbc.columnsv WHERE databasename = DATABASE AND tablename = 'tester_new_transaction_history' AND columnname = '_fivetran_deleted') t WHERE t.c <> 1"
+      "sql": "SELECT 1 AS x FROM (SELECT COUNT(*) AS c FROM dbc.columnsv WHERE databasename = DATABASE AND tablename = 'tester_new_transaction_history' AND columnname = '_fivetran_deleted') t WHERE t.c <> 1"
     },
     {
       "name": "tester_new_transaction_history has no _fivetran_start column anymore (soft-delete mode)",
-      "sql": "SELECT 1 FROM dbc.columnsv WHERE databasename = DATABASE AND tablename = 'tester_new_transaction_history' AND columnname = '_fivetran_start'"
+      "sql": "SELECT 1 AS x FROM dbc.columnsv WHERE databasename = DATABASE AND tablename = 'tester_new_transaction_history' AND columnname = '_fivetran_start'"
     },
     {
       "name": "all tester_new_transaction_history rows are not deleted (_fivetran_deleted=0)",
-      "sql": "SELECT 1 FROM tester_new_transaction_history WHERE _fivetran_deleted <> 0"
+      "sql": "SELECT 1 AS x FROM tester_new_transaction_history WHERE _fivetran_deleted <> 0"
     }
   ]
 }

--- a/scripts/sdk_tester_matrix/expectations/schema_migrations_input_sync_modes.json
+++ b/scripts/sdk_tester_matrix/expectations/schema_migrations_input_sync_modes.json
@@ -1,0 +1,59 @@
+{
+  "_comment": "Expectations after schema_migrations_input_sync_modes.json. From manual session: 5 migrations — AddColumnInHistoryMode(article), DropColumnInHistoryMode(desc), CopyTableToHistoryMode(transaction->new_transaction_history), MigrateSoftDeleteToHistory(transaction), MigrateHistoryToSoftDelete(new_transaction_history). End state: tester_transaction = 6 rows in history mode (with _fivetran_start/_end/_active); tester_transaction_history = 13 rows (article populated for active versions, desc nulled for active versions); tester_new_transaction_history = 6 rows in soft-delete mode (with _fivetran_deleted, no _fivetran_start).",
+  "tables_required": [
+    "tester_transaction",
+    "tester_transaction_history",
+    "tester_new_transaction_history"
+  ],
+  "lob_columns_to_strip": [],
+  "assertions": [
+    {
+      "name": "tester_transaction has 6 rows after MigrateSoftDeleteToHistory",
+      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM tester_transaction) t WHERE t.c <> 6"
+    },
+    {
+      "name": "tester_transaction was migrated to history mode (has _fivetran_active column)",
+      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM dbc.columnsv WHERE databasename = DATABASE AND tablename = 'tester_transaction' AND columnname = '_fivetran_active') t WHERE t.c <> 1"
+    },
+    {
+      "name": "tester_transaction has no _fivetran_deleted column anymore (history mode)",
+      "sql": "SELECT 1 FROM dbc.columnsv WHERE databasename = DATABASE AND tablename = 'tester_transaction' AND columnname = '_fivetran_deleted'"
+    },
+    {
+      "name": "all tester_transaction rows are active (_fivetran_active=1)",
+      "sql": "SELECT 1 FROM tester_transaction WHERE _fivetran_active <> 1"
+    },
+    {
+      "name": "tester_transaction_history has 13 rows (6 base + AddColumn versioning + DropColumn versioning)",
+      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM tester_transaction_history) t WHERE t.c <> 13"
+    },
+    {
+      "name": "tester_transaction_history has the article column (AddColumnInHistoryMode)",
+      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM dbc.columnsv WHERE databasename = DATABASE AND tablename = 'tester_transaction_history' AND columnname = 'article') t WHERE t.c <> 1"
+    },
+    {
+      "name": "active tester_transaction_history rows have article = 'Ordered article'",
+      "sql": "SELECT 1 FROM tester_transaction_history WHERE _fivetran_active = 1 AND (article IS NULL OR article <> 'Ordered article')"
+    },
+    {
+      "name": "active tester_transaction_history rows have desc = NULL (DropColumnInHistoryMode soft-drop)",
+      "sql": "SELECT 1 FROM tester_transaction_history WHERE _fivetran_active = 1 AND \"desc\" IS NOT NULL"
+    },
+    {
+      "name": "tester_new_transaction_history has 6 rows after MigrateHistoryToSoftDelete",
+      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM tester_new_transaction_history) t WHERE t.c <> 6"
+    },
+    {
+      "name": "tester_new_transaction_history has _fivetran_deleted column (soft-delete mode)",
+      "sql": "SELECT 1 FROM (SELECT COUNT(*) AS c FROM dbc.columnsv WHERE databasename = DATABASE AND tablename = 'tester_new_transaction_history' AND columnname = '_fivetran_deleted') t WHERE t.c <> 1"
+    },
+    {
+      "name": "tester_new_transaction_history has no _fivetran_start column anymore (soft-delete mode)",
+      "sql": "SELECT 1 FROM dbc.columnsv WHERE databasename = DATABASE AND tablename = 'tester_new_transaction_history' AND columnname = '_fivetran_start'"
+    },
+    {
+      "name": "all tester_new_transaction_history rows are not deleted (_fivetran_deleted=0)",
+      "sql": "SELECT 1 FROM tester_new_transaction_history WHERE _fivetran_deleted <> 0"
+    }
+  ]
+}

--- a/scripts/sdk_tester_matrix/inputs/input.json
+++ b/scripts/sdk_tester_matrix/inputs/input.json
@@ -1,0 +1,238 @@
+{
+   "create_table": {
+      "transaction": {
+         "columns": {
+            "id": "INT",
+            "amount_double": "DOUBLE",
+            "amount_float": "FLOAT",
+            "amount_decimal": {
+               "type": "DECIMAL",
+               "precision": 38,
+               "scale": 10
+            },
+            "flag": "BOOLEAN",
+            "short_val": "SHORT",
+            "long_val": "LONG",
+            "time_val": "NAIVE_TIME",
+            "date_val": "NAIVE_DATE",
+            "datetime_val": "NAIVE_DATETIME",
+            "utc_val": "UTC_DATETIME",
+            "binary_val": "BINARY",
+            "xml_val": "XML",
+            "string_val": "STRING",
+            "json_val": "JSON",
+            "old_column": "STRING"
+         },
+         "primary_key": [
+            "id"
+         ],
+         "history_mode": true
+      },
+      "campaign": {
+         "columns": {
+            "name": "STRING",
+            "num_decimal": {
+               "type": "DECIMAL",
+               "precision": 6,
+               "scale": 3
+            },
+            "start_date": "NAIVE_DATE",
+            "end_datetime": "UTC_DATETIME",
+            "is_active": "BOOLEAN"
+         },
+         "primary_key": []
+      },
+      "composite_table": {
+         "columns": {
+            "pk1": "INT",
+            "pk2": "STRING",
+            "old_pk": "STRING",
+            "value": "STRING"
+         },
+         "primary_key": [
+            "pk1",
+            "pk2",
+            "old_pk"
+         ]
+      }
+   },
+   "alter_table": {
+      "transaction": {
+         "columns": {
+            "id": "INT",
+            "amount_double": "DOUBLE",
+            "amount_float": "FLOAT",
+            "amount_decimal": {
+               "type": "DECIMAL",
+               "precision": 38,
+               "scale": 15
+            },
+            "flag": "BOOLEAN",
+            "short_val": "SHORT",
+            "long_val": "LONG",
+            "time_val": "NAIVE_TIME",
+            "date_val": "NAIVE_DATE",
+            "datetime_val": "NAIVE_DATETIME",
+            "utc_val": "UTC_DATETIME",
+            "binary_val": "BINARY",
+            "xml_val": "XML",
+            "string_val": "STRING",
+            "json_val": "JSON",
+            "new_column": "STRING"
+         },
+         "primary_key": [
+            "id"
+         ],
+         "history_mode": true
+      },
+      "composite_table": {
+         "columns": {
+            "pk1": "INT",
+            "pk2": "STRING",
+            "new_pk": "STRING",
+            "value": "STRING"
+         },
+         "primary_key": [
+            "pk1",
+            "pk2",
+            "new_pk"
+         ]
+      }
+   },
+   "ops": [
+      {
+         "upsert": {
+            "transaction": [
+               {
+                  "id": 1,
+                  "amount_double": 100.123456789,
+                  "amount_float": 10.12,
+                  "amount_decimal": 12345.123456789012345,
+                  "flag": true,
+                  "short_val": 123,
+                  "long_val": 1234567890123,
+                  "time_val": "10:15:30",
+                  "date_val": "2023-10-27",
+                  "datetime_val": "2023-10-27T15:00:00",
+                  "utc_val": "2023-10-27T15:00:00.000Z",
+                  "binary_val": "[B@7d4991ad",
+                  "xml_val": "<tag>This is xml</tag>",
+                  "string_val": "Some text",
+                  "json_val": "{\"a\":123}",
+                  "new_column": "New data",
+                  "op_time": "2005-05-23T20:57:00Z"
+               },
+               {
+                  "id": 2,
+                  "amount_double": 200.987654321,
+                  "amount_float": 20.34,
+                  "amount_decimal": 12345678901234567890123.12345,
+                  "flag": false,
+                  "short_val": -123,
+                  "long_val": 9876543210123,
+                  "time_val": "11:11:11",
+                  "date_val": "2023-10-28",
+                  "datetime_val": "2023-10-28T11:00:00",
+                  "utc_val": "2023-10-28T11:00:00.000Z",
+                  "binary_val": "[B@7d4991ad",
+                  "xml_val": "<tag>XML test</tag>",
+                  "string_val": "Another text",
+                  "json_val": "{\"b\":456}",
+                  "new_column": "New data 1",
+                  "op_time": "2005-05-23T20:57:00Z"
+               },
+               {
+                  "id": 1,
+                  "amount_double": 300.111,
+                  "amount_float": 30.22,
+                  "amount_decimal": 12345.123456789012345,
+                  "flag": true,
+                  "short_val": 0,
+                  "long_val": 0,
+                  "time_val": "12:12:12",
+                  "date_val": "2023-10-29",
+                  "datetime_val": "2023-10-29T12:00:00",
+                  "utc_val": "2023-10-29T12:00:00.000Z",
+                  "binary_val": "[B@7d4991ad",
+                  "xml_val": "<tag>Duplicate PK</tag>",
+                  "string_val": "Duplicate text",
+                  "json_val": "{\"c\":789}",
+                  "new_column": "New data 2",
+                  "op_time": "2005-05-23T20:58:00Z"
+               }
+            ],
+            "campaign": [
+               {
+                  "_fivetran_id": "abc-123-xyz",
+                  "name": "Campaign A",
+                  "num_decimal": 100.123,
+                  "start_date": "2023-01-01",
+                  "end_datetime": "2023-12-31T23:59:59.000Z",
+                  "is_active": true
+               }
+            ],
+            "composite_table": [
+               {
+                  "pk1": 1,
+                  "pk2": "A",
+                  "new_pk": "1",
+                  "value": "Value 1"
+               },
+               {
+                  "pk1": 1,
+                  "pk2": "B",
+                  "new_pk": "2",
+                  "value": "Value 2"
+               }
+            ]
+         }
+      },
+      {
+         "truncate_before": [
+            "campaign"
+         ]
+      },
+      {
+         "soft_truncate_before": [
+            "composite_table"
+         ]
+      },
+      {
+         "update": {
+            "transaction": [
+               {
+                  "id": 1,
+                  "amount_double": 400.555,
+                  "flag": false,
+                  "op_time": "2023-10-30T15:00:00Z"
+               }
+            ]
+         }
+      },
+      {
+         "delete": {
+            "transaction": [
+               {
+                  "id": 2,
+                  "op_time": "2023-10-30T16:00:00Z"
+               }
+            ]
+         }
+      },
+      {
+         "soft_delete": {
+            "transaction": [
+               {
+                  "id": 1,
+                  "op_time": "2023-10-30T16:30:00Z"
+               }
+            ]
+         }
+      }
+   ],
+   "describe_table": [
+      "transaction",
+      "campaign",
+      "composite_table"
+   ]
+}

--- a/scripts/sdk_tester_matrix/inputs/schema_migrations_input_ddl.json
+++ b/scripts/sdk_tester_matrix/inputs/schema_migrations_input_ddl.json
@@ -1,0 +1,53 @@
+{
+  "create_table" : {
+    "transaction": {
+      "columns": {
+        "id": "INT",
+        "amount": "DOUBLE",
+        "desc": "STRING"
+      },
+      "primary_key": ["id"]
+    }
+  },
+  "ops" : [
+    {
+      "upsert": {
+        "transaction": [
+          {"id":1, "amount": 100.45, "desc": null},
+          {"id":2, "amount": 150.33, "desc": "two"},
+          {"id":3, "amount": 150.33, "desc": "two"},
+          {"id":4, "amount": 150.33, "desc": "two"},
+          {"id":10, "amount": 200, "desc": "three"},
+          {"id":20, "amount": 50, "desc": "money"}
+        ]
+      }
+    }
+  ],
+  "schema_migration" : [
+    {
+      "add_column": [
+        {
+          "table": "transaction",
+          "column": "operation_time",
+          "data_type": "UTC_DATETIME"
+        }
+      ],
+      "change_column_data_type": [
+        {
+          "table": "transaction",
+          "column": "amount",
+          "data_type": "FLOAT"
+        }
+      ],
+      "drop_column": [
+        {
+          "table": "transaction",
+          "column": "desc"
+        }
+      ]
+    }
+  ],
+  "describe_table" : [
+    "transaction"
+  ]
+}

--- a/scripts/sdk_tester_matrix/inputs/schema_migrations_input_dml.json
+++ b/scripts/sdk_tester_matrix/inputs/schema_migrations_input_dml.json
@@ -1,0 +1,98 @@
+{
+   "create_table" : {
+      "transaction": {
+         "columns": {
+            "id": "INT",
+            "amount" : "DOUBLE",
+            "desc": "STRING"
+         },
+         "primary_key": ["id"]
+      },
+      "transaction_drop": {
+         "columns": {
+            "id": "INT",
+            "amount" : "DOUBLE",
+            "desc": "STRING"
+         },
+         "primary_key": ["id"]
+      }
+   },
+   "ops" : [
+      {
+         "upsert": {
+            "transaction": [
+               {"id":1, "amount": 100.45, "desc":null},
+               {"id":2, "amount": 150.33, "desc": "two"},
+               {"id":3, "amount": 150.33, "desc": "two"},
+               {"id":4, "amount": 150.33, "desc": "two"},
+               {"id":10, "amount": 200, "desc": "three"},
+               {"id":20, "amount": 50, "desc": "money"}
+            ],
+            "transaction_drop": [
+               {"id":1, "amount": 100.45, "desc":null},
+               {"id":2, "amount": 150.33, "desc": "two"}
+            ]
+         }
+      }
+   ],
+   "schema_migration" : [
+      {
+         "copy_column": [
+            {
+               "table": "transaction",
+               "from_column": "desc",
+               "to_column": "desc_detailed"
+            }
+         ],
+         "update_column_value": [
+            {
+               "table": "transaction",
+               "column": "amount",
+               "value": "202.57"
+            }
+         ],
+         "add_column_with_default_value": [
+            {
+               "table": "transaction",
+               "column": "operation_time",
+               "data_type": "UTC_DATETIME",
+               "default_value": "2005-05-28T20:57:00Z"
+            }
+         ],
+         "set_column_to_null": [
+            {
+               "table": "transaction",
+               "column": "desc"
+            }
+         ],
+         "copy_table": [
+            {
+               "from_table": "transaction",
+               "to_table": "transaction_new"
+            }
+         ],
+         "rename_column": [
+            {
+               "table": "transaction",
+               "from_column": "amount",
+               "to_column": "amount_renamed"
+            }
+         ],
+         "rename_table": [
+            {
+               "from_table": "transaction_new",
+               "to_table": "transaction_renamed"
+            }
+         ],
+         "drop_table": [
+            {
+               "table": "transaction_drop"
+            }
+         ]
+      }
+   ],
+   "describe_table" : [
+      "transaction",
+      "transaction_renamed"
+   ]
+}

--- a/scripts/sdk_tester_matrix/inputs/schema_migrations_input_sync_modes.json
+++ b/scripts/sdk_tester_matrix/inputs/schema_migrations_input_sync_modes.json
@@ -1,0 +1,89 @@
+{
+   "create_table" : {
+      "transaction": {
+         "columns": {
+            "id": "INT",
+            "amount" : "DOUBLE",
+            "desc": "STRING"
+         },
+         "primary_key": ["id"],
+         "history_mode": false
+      },
+      "transaction_history": {
+         "columns": {
+            "id": "INT",
+            "amount" : "DOUBLE",
+            "desc": "STRING"
+         },
+         "primary_key": ["id"],
+         "history_mode": true
+      }
+   },
+   "ops" : [
+      {
+         "upsert": {
+            "transaction": [
+               {"id":1, "amount": 100.45, "desc":null},
+               {"id":2, "amount": 150.33, "desc": "two"},
+               {"id":3, "amount": 150.33, "desc": "two"},
+               {"id":4, "amount": 150.33, "desc": "two"},
+               {"id":10, "amount": 200, "desc": "three"},
+               {"id":20, "amount": 50, "desc": "money"}
+            ],
+            "transaction_history": [
+               {"id":1, "amount": 100.45, "desc":null, "op_time":"2005-05-23T20:57:00Z"},
+               {"id":2, "amount": 150.33, "desc": "two", "op_time":"2005-05-23T20:57:00Z"},
+               {"id":3, "amount": 150.33, "desc": "two", "op_time":"2005-05-23T20:57:00Z"},
+               {"id":4, "amount": 150.33, "desc": "two", "op_time":"2005-05-23T20:57:00Z"},
+               {"id":10, "amount": 200, "desc": "three", "op_time":"2005-05-26T20:57:00Z"},
+               {"id":10, "amount": 100, "desc": "three", "op_time":"2005-05-26T20:58:00Z"},
+               {"id":20, "amount": 50, "desc": "money", "op_time":"2005-05-26T21:57:00Z"}
+            ]
+         }
+      }
+   ],
+   "schema_migration" : [
+      {
+         "add_column_in_history_mode": [
+            {
+               "table": "transaction_history",
+               "column": "article",
+               "data_type": "STRING",
+               "default_value": "Ordered article",
+               "operation_timestamp": "2005-05-28T20:57:00Z"
+            }
+         ],
+         "drop_column_in_history_mode": [
+            {
+               "table": "transaction_history",
+               "column": "desc",
+               "operation_timestamp": "2005-05-28T20:57:00Z"
+            }
+         ],
+         "copy_table_to_history_mode": [
+            {
+               "from_table": "transaction",
+               "to_table": "new_transaction_history",
+               "deleted_column": "_fivetran_deleted"
+            }
+         ],
+         "migrate_soft_delete_to_history": [
+            {
+               "table": "transaction",
+               "deleted_column": "_fivetran_deleted"
+            }
+         ],
+         "migrate_history_to_soft_delete": [
+            {
+               "table": "new_transaction_history",
+               "deleted_column": "_fivetran_deleted"
+            }
+         ]
+      }
+   ],
+   "describe_table" : [
+      "transaction",
+      "transaction_history",
+      "new_transaction_history"
+   ]
+}

--- a/scripts/sdk_tester_matrix/run.py
+++ b/scripts/sdk_tester_matrix/run.py
@@ -1,0 +1,721 @@
+#!/usr/bin/env python3
+"""
+SDK Tester Matrix - single-click runner for the Fivetran SDK
+destination-connector-tester against our locally-running Teradata destination.
+
+Runs all combos of {input.json, schema_migrations_input_ddl.json,
+schema_migrations_input_dml.json, schema_migrations_input_sync_modes.json}
+x {TMODE=ANSI, TMODE=TERA, use.fastload=true} (12 combos by default), with:
+  * pre-run cleanup (drops the known tester_* tables)
+  * per-combo configuration.json generation (the tester reads this and forwards
+    its contents as the gRPC configurationMap)
+  * input JSON patching (auto-fixes upstream `[B@xxx` byte[].toString() junk;
+    optionally strips LOB columns for the FastLoad input.json combo)
+  * docker tester invocation with streaming logs
+  * BTEQ-driven validation of expected end-state
+  * console + JSON report
+
+Prereqs
+-------
+  * `bteq` and `docker` on PATH
+  * Connector JAR running on port 50052 (in another terminal)
+  * Env vars: TD_HOST, TD_USER, TD_PASSWORD, TD_DATABASE
+  * The 4 canonical input JSONs in C:\\Fivetran (or whichever
+    paths.canonical_inputs_dir is set to in config.json)
+
+Usage
+-----
+    python scripts/sdk_tester_matrix/run.py
+    python scripts/sdk_tester_matrix/run.py --only input__FastLoad,dml__TERA
+    python scripts/sdk_tester_matrix/run.py --fail-fast --purge-generated
+    python scripts/sdk_tester_matrix/run.py --dry-run
+
+Exit codes
+----------
+    0  - every combo passed (tester clean + every assertion 0 rows)
+    1  - at least one combo failed validation or tester
+    2  - orchestrator fault: bad config, missing env var, missing CLI tool,
+         connector port unreachable, BTEQ logon failure
+"""
+
+import sys
+if sys.version_info < (3, 7):
+    sys.stderr.write("ERROR: Python 3.7+ required; got {}.{}.\n".format(
+        sys.version_info.major, sys.version_info.minor))
+    sys.exit(2)
+
+import argparse
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import time
+from datetime import datetime
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# tester_* tables created by any combo of the 4 SDK input JSONs. Dropped
+# (idempotently) before each combo so every run starts from a clean slate.
+TESTER_TABLES_TO_DROP = [
+    "tester_transaction",
+    "tester_campaign",
+    "tester_composite_table",
+    "tester_composite_table_alter_tmp",
+    "tester_transaction_alter_tmp",
+    "tester_transaction_drop",
+    "tester_transaction_new",
+    "tester_transaction_renamed",
+    "tester_transaction_history",
+    "tester_new_transaction_history",
+]
+
+# Teradata error 3807 = "Object … does not exist". Suppressed during the
+# pre-run drop so a missing table is not a fatal error.
+TD_ERR_TABLE_NOT_FOUND = 3807
+
+# BTEQ exit codes we care about (per Teradata docs).
+BTEQ_RC_OK = 0
+BTEQ_RC_WARNING = 4
+BTEQ_RC_DB_ERROR = 8
+BTEQ_RC_CONNECTION = 12
+
+# Tag prefix used in assertion SELECTs to anchor result parsing.
+ASSERT_TAG_PREFIX = "MATRIXASSERT"
+
+
+# ---------------------------------------------------------------------------
+# Config loading
+# ---------------------------------------------------------------------------
+
+def load_config(path):
+    """Read config.json, resolve *_env keys to actual values from os.environ.
+    Returns the resolved dict. Hard-fails (exit 2) on missing env vars or
+    structurally invalid config, listing every problem at once.
+    """
+    if not path.is_file():
+        sys.stderr.write("ERROR: config file not found: {}\n".format(path))
+        sys.exit(2)
+
+    try:
+        cfg = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        sys.stderr.write("ERROR: config not valid JSON ({}): {}\n".format(path, e))
+        sys.exit(2)
+
+    problems = []
+    for section in ("teradata", "connector", "docker", "paths", "matrix",
+                    "configuration_template"):
+        if section not in cfg:
+            problems.append("missing top-level section: {}".format(section))
+
+    td = cfg.get("teradata", {}) or {}
+    resolved_td = {}
+    for key, env_key in (("host", "host_env"), ("user", "user_env"),
+                         ("password", "password_env"),
+                         ("database", "database_env")):
+        env_var = td.get(env_key)
+        if not env_var:
+            problems.append("teradata.{} not set in config".format(env_key))
+            continue
+        val = os.environ.get(env_var)
+        if not val:
+            problems.append("env var ${} not set (referenced by teradata.{})"
+                            .format(env_var, env_key))
+            continue
+        resolved_td[key] = val
+    cfg["teradata_resolved"] = resolved_td
+
+    matrix = cfg.get("matrix", {}) or {}
+    if not matrix.get("inputs") or not matrix.get("configs"):
+        problems.append("matrix.inputs and matrix.configs both required")
+
+    if problems:
+        sys.stderr.write("ERROR: config invalid:\n")
+        for p in problems:
+            sys.stderr.write("  - {}\n".format(p))
+        sys.exit(2)
+
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Matrix expansion
+# ---------------------------------------------------------------------------
+
+def expand_matrix(cfg, only=None):
+    """Build the list of combo dicts. Order: input outermost, config inner.
+    Combo id format: '<input_name>__<config_id>' (e.g. 'input__ANSI').
+    """
+    inputs = cfg["matrix"]["inputs"]
+    configs = cfg["matrix"]["configs"]
+    canonical_dir = Path(cfg["paths"]["canonical_inputs_dir"])
+    expectations_dir = Path(cfg["paths"]["expectations_dir"])
+
+    only_set = None
+    if only:
+        only_set = {s.strip() for s in only.split(",") if s.strip()}
+
+    combos = []
+    for inp in inputs:
+        for conf in configs:
+            cid = "{}__{}".format(inp["name"], conf["id"])
+            if only_set and cid not in only_set:
+                continue
+            exp_key = ("fastload_expectations"
+                       if conf.get("fastload") and inp.get("fastload_expectations")
+                       else "expectations")
+            combos.append({
+                "id": cid,
+                "input_name": inp["name"],
+                "input_file": inp["file"],
+                "input_path": canonical_dir / inp["file"],
+                "tmode": conf["tmode"],
+                "fastload": bool(conf.get("fastload", False)),
+                "expectations_path": expectations_dir / inp[exp_key],
+            })
+
+    if only_set:
+        unknown = only_set - {c["id"] for c in combos}
+        if unknown:
+            sys.stderr.write("ERROR: --only references unknown combos: {}\n"
+                             .format(", ".join(sorted(unknown))))
+            sys.exit(2)
+
+    return combos
+
+
+# ---------------------------------------------------------------------------
+# Connector port probe
+# ---------------------------------------------------------------------------
+
+def probe_grpc_port(host, port, timeout=2.0):
+    """Cheap TCP probe - returns True if a SYN/ACK comes back.
+    Always probes 127.0.0.1 from the orchestrator's perspective; the
+    docker container reaches the same gRPC server via host.docker.internal.
+    """
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def require_port_or_fail(cfg, label):
+    port = cfg["connector"]["port"]
+    if not probe_grpc_port(cfg["connector"]["host"], port):
+        sys.stderr.write(
+            "ERROR ({}): connector not reachable on 127.0.0.1:{}.\n"
+            "  hint: start the connector in another terminal:\n"
+            "        java -jar build/libs/TeradataDestination.jar\n"
+            .format(label, port))
+        sys.exit(2)
+
+
+# ---------------------------------------------------------------------------
+# BTEQ runner
+# ---------------------------------------------------------------------------
+
+def find_tool(name, hint):
+    exe = shutil.which(name)
+    if not exe:
+        sys.stderr.write("ERROR: '{}' not on PATH.\n  hint: {}\n".format(name, hint))
+        sys.exit(2)
+    return exe
+
+
+def bteq_run(cfg, sql_text, label, generated_dir):
+    """Run BTEQ with `sql_text` piped in. Writes `<label>.sql` and `<label>.log`
+    into generated_dir/bteq/. Returns (rc, stdout, stderr).
+    """
+    bteq_dir = generated_dir / "bteq"
+    bteq_dir.mkdir(parents=True, exist_ok=True)
+    sql_path = bteq_dir / "{}.sql".format(label)
+    log_path = bteq_dir / "{}.log".format(label)
+    sql_path.write_text(sql_text, encoding="utf-8")
+
+    bteq = find_tool("bteq", "install Teradata Tools and Utilities")
+    proc = subprocess.run([bteq], input=sql_text, capture_output=True, text=True)
+    log_path.write_text(
+        "$ bteq <<EOF\n{}\nEOF\n\n--- STDOUT ---\n{}\n--- STDERR ---\n{}\n--- RC {} ---\n"
+        .format(sql_text, proc.stdout, proc.stderr, proc.returncode),
+        encoding="utf-8")
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def bteq_logon_block(cfg):
+    td = cfg["teradata_resolved"]
+    return ".LOGON {}/{},{}\n".format(td["host"], td["user"], td["password"])
+
+
+def drop_tester_tables(cfg, combo_id, generated_dir):
+    """Run the standard 10-table drop. Suppresses 3807 ('table does not exist')
+    so this is idempotent. Restores severity afterwards.
+    """
+    drops = "\n".join(
+        "DROP TABLE \"{}\".\"{}\";".format(cfg["teradata_resolved"]["database"], t)
+        for t in TESTER_TABLES_TO_DROP
+    )
+    sql = (
+        ".SET WIDTH 500\n"
+        ".SET FORMAT OFF\n"
+        + bteq_logon_block(cfg)
+        + ".SET ERRORLEVEL {} SEVERITY 0\n".format(TD_ERR_TABLE_NOT_FOUND)
+        + drops + "\n"
+        + ".SET ERRORLEVEL {} SEVERITY 8\n".format(TD_ERR_TABLE_NOT_FOUND)
+        + ".LOGOFF\n.QUIT\n"
+    )
+    rc, out, err = bteq_run(cfg, sql, "{}__drop".format(combo_id), generated_dir)
+    if rc == BTEQ_RC_CONNECTION:
+        sys.stderr.write("ERROR: BTEQ logon failed during drop - see "
+                         "{}/bteq/{}__drop.log\n".format(generated_dir, combo_id))
+        sys.exit(2)
+    # Anything other than 0 (clean) or warning (4) for the drop is an
+    # orchestrator fault - we already suppressed "not exist".
+    if rc not in (BTEQ_RC_OK, BTEQ_RC_WARNING):
+        sys.stderr.write(
+            "WARNING: drop block returned rc={} - proceeding anyway.\n".format(rc))
+
+
+# ---------------------------------------------------------------------------
+# configuration.json + input.json patching
+# ---------------------------------------------------------------------------
+
+def write_configuration_json(cfg, combo, generated_dir):
+    """Write C:\\Fivetran\\configuration.json (the tester reads this) plus an
+    archive copy under generated_dir/configurations/<combo_id>.json.
+    """
+    td = cfg["teradata_resolved"]
+    contents = dict(cfg["configuration_template"])
+    contents["host"] = td["host"]
+    contents["user"] = td["user"]
+    contents["td2password"] = td["password"]
+    contents["tmode"] = combo["tmode"]
+    contents["use.fastload"] = "true" if combo["fastload"] else "false"
+
+    canonical_dir = Path(cfg["paths"]["canonical_inputs_dir"])
+    live_path = canonical_dir / "configuration.json"
+    live_path.write_text(json.dumps(contents, indent=4), encoding="utf-8")
+
+    archive_dir = generated_dir / "configurations"
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    archive_path = archive_dir / "{}.json".format(combo["id"])
+    archive_path.write_text(json.dumps(contents, indent=4), encoding="utf-8")
+    return live_path
+
+
+def import_patch_tester_inputs():
+    """Lazy-import patch_tester_inputs from the parent scripts/ dir."""
+    parent = str(Path(__file__).resolve().parent.parent)
+    if parent not in sys.path:
+        sys.path.insert(0, parent)
+    import patch_tester_inputs  # noqa: E402
+    return patch_tester_inputs
+
+
+def _strip_lob_columns(node, lob_names):
+    """Recursively walk the JSON and drop every key whose name matches
+    a LOB column. Handles both:
+      * column declarations:  "columns": {"binary_val": "BINARY", ...}
+      * row payloads:         {"id": 1, "binary_val": "...", ...}
+    The canonical Fivetran SDK input JSONs use a dict (name -> type) for
+    column declarations, not a list of {name, type} entries, so the same
+    "delete matching keys" rule covers both cases.
+    """
+    lob = set(lob_names)
+    if isinstance(node, list):
+        return [_strip_lob_columns(v, lob_names) for v in node]
+    if isinstance(node, dict):
+        return {k: _strip_lob_columns(v, lob_names)
+                for k, v in node.items() if k not in lob}
+    return node
+
+
+def patch_input(combo, expectation, generated_dir):
+    """Read the canonical input JSON, fix the upstream `[B@xxx` byte[].toString()
+    junk via patch_tester_inputs, optionally strip LOB columns, and write to
+    canonical_inputs_dir/<combo_id>.json so docker sees it via the bind mount.
+    Returns the file name (relative to canonical_inputs_dir) for --input-file.
+    """
+    src = combo["input_path"]
+    if not src.is_file():
+        sys.stderr.write("ERROR: canonical input not found: {}\n".format(src))
+        sys.exit(2)
+
+    raw = json.loads(src.read_text(encoding="utf-8"))
+
+    pti = import_patch_tester_inputs()
+    counter = [0]
+    patched = pti.patch_value(raw, counter)
+
+    lob = expectation.get("lob_columns_to_strip") or []
+    if lob and combo["fastload"]:
+        patched = _strip_lob_columns(patched, lob)
+
+    # Archive the patched copy under generated/inputs/, AND drop it next to
+    # the canonical so docker's bind mount sees it.
+    inputs_archive = generated_dir / "inputs"
+    inputs_archive.mkdir(parents=True, exist_ok=True)
+    archive_path = inputs_archive / "{}.json".format(combo["id"])
+    archive_path.write_text(json.dumps(patched, indent=2), encoding="utf-8")
+
+    canonical_dir = src.parent
+    live_name = "{}.json".format(combo["id"])
+    live_path = canonical_dir / live_name
+    live_path.write_text(json.dumps(patched, indent=2), encoding="utf-8")
+
+    return live_name, counter[0]
+
+
+# ---------------------------------------------------------------------------
+# Docker tester runner
+# ---------------------------------------------------------------------------
+
+def build_docker_argv(cfg, input_filename):
+    d = cfg["docker"]
+    argv = [
+        "docker", "run",
+        "--memory={}".format(d["memory"]),
+        "-e", "JAVA_TOOL_OPTIONS={}".format(d["java_tool_options"]),
+        "--mount", "type=bind,source={},target={}".format(d["mount_source"],
+                                                          d["mount_target"]),
+        "-a", "STDIN", "-a", "STDOUT", "-a", "STDERR",
+        "-e", "WORKING_DIR={}".format(d["working_dir_env"]),
+        "-e", "GRPC_HOSTNAME={}".format(cfg["connector"]["host"]),
+        "--network={}".format(d["network"]),
+        "--rm",
+        "{}:{}".format(d["image"], d["tag"]),
+        "--tester-type", "destination",
+        "--port", str(cfg["connector"]["port"]),
+        "--input-file", input_filename,
+    ]
+    argv.extend(d.get("extra_args", []))
+    return argv
+
+
+def run_tester(cfg, combo, input_filename, generated_dir):
+    """Spawn docker, stream stdout/stderr to console + log file. Returns
+    (exit_code, log_path, duration_s).
+    """
+    log_dir = generated_dir / "tester-logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / "{}.log".format(combo["id"])
+    argv = build_docker_argv(cfg, input_filename)
+
+    sys.stderr.write(">>> docker: {}\n".format(" ".join(argv)))
+    started = time.time()
+    with log_path.open("w", encoding="utf-8") as logf:
+        logf.write("$ " + " ".join(argv) + "\n\n")
+        proc = subprocess.Popen(
+            argv,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+        try:
+            for line in iter(proc.stdout.readline, ""):
+                sys.stderr.write(line)
+                logf.write(line)
+        finally:
+            proc.stdout.close()
+        rc = proc.wait()
+    return rc, log_path, time.time() - started
+
+
+# ---------------------------------------------------------------------------
+# Assertion compilation + parsing
+# ---------------------------------------------------------------------------
+
+def compile_assertions(cfg, expectation):
+    """Build a single BTEQ script that runs every assertion. Each assertion
+    emits one row tagged 'MATRIXASSERT_NNN' followed by the bad-row count.
+    """
+    db = cfg["teradata_resolved"]["database"]
+    lines = [
+        ".SET WIDTH 500",
+        ".SET FORMAT OFF",
+        ".SET FOLDLINE OFF",
+        ".SET TITLEDASHES OFF",
+        bteq_logon_block(cfg).rstrip("\n"),
+        "DATABASE \"{}\";".format(db),
+    ]
+    assertions = expectation.get("assertions", []) or []
+    for i, a in enumerate(assertions):
+        tag = "{}_{:03d}".format(ASSERT_TAG_PREFIX, i + 1)
+        sql = a["sql"].strip().rstrip(";")
+        lines.append(
+            "SELECT '{}' AS tag_, "
+            "(SELECT COUNT(*) FROM ({}) bad_) AS cnt_;".format(tag, sql)
+        )
+    lines.append(".LOGOFF")
+    lines.append(".QUIT")
+    return "\n".join(lines) + "\n"
+
+
+_TAG_RE = re.compile(
+    r"^\s*" + ASSERT_TAG_PREFIX + r"_(\d{3})\s+(\d+)\s*$",
+    re.MULTILINE,
+)
+
+
+def parse_assertion_results(stdout, assertions):
+    """Pull (idx, count) pairs from BTEQ stdout. Returns a list aligned with
+    `assertions`: each entry {name, count, ok, found}.
+    """
+    found = {}
+    for m in _TAG_RE.finditer(stdout):
+        idx = int(m.group(1))
+        cnt = int(m.group(2))
+        found[idx] = cnt
+    out = []
+    for i, a in enumerate(assertions):
+        idx = i + 1
+        cnt = found.get(idx)
+        out.append({
+            "name": a["name"],
+            "count": cnt,
+            "ok": cnt == 0,
+            "found": cnt is not None,
+        })
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Per-combo orchestration
+# ---------------------------------------------------------------------------
+
+def run_combo(cfg, combo, generated_dir, idx, total):
+    label = "[{}/{}] {} x {}".format(idx, total, combo["input_name"],
+                                     "FastLoad" if combo["fastload"]
+                                     else combo["tmode"])
+    sys.stderr.write("\n=== {} ===\n".format(label))
+    require_port_or_fail(cfg, label)
+
+    expectation = json.loads(combo["expectations_path"].read_text(encoding="utf-8"))
+
+    drop_tester_tables(cfg, combo["id"], generated_dir)
+    write_configuration_json(cfg, combo, generated_dir)
+    input_filename, junk_replaced = patch_input(combo, expectation, generated_dir)
+    if junk_replaced:
+        sys.stderr.write("    (patched {} byte[].toString() junk values)\n"
+                         .format(junk_replaced))
+
+    tester_rc, tester_log, tester_dur = run_tester(
+        cfg, combo, input_filename, generated_dir)
+
+    assertions = expectation.get("assertions", []) or []
+    if assertions:
+        sql = compile_assertions(cfg, expectation)
+        rc, out, _err = bteq_run(cfg, sql, "{}__assert".format(combo["id"]),
+                                 generated_dir)
+        if rc == BTEQ_RC_CONNECTION:
+            sys.stderr.write("ERROR: BTEQ logon failed during validation.\n")
+            sys.exit(2)
+        results = parse_assertion_results(out, assertions)
+        validate_pass = all(r["ok"] and r["found"] for r in results)
+        validate_rc = rc
+    else:
+        results = []
+        validate_pass = tester_rc == 0
+        validate_rc = 0
+
+    overall = (tester_rc == 0) and validate_pass
+
+    sys.stderr.write("    tester rc={}  validate {}/{}\n".format(
+        tester_rc,
+        sum(1 for r in results if r["ok"] and r["found"]),
+        len(results),
+    ))
+
+    return {
+        "id": combo["id"],
+        "input": combo["input_name"],
+        "config": "FastLoad" if combo["fastload"] else combo["tmode"],
+        "tmode": combo["tmode"],
+        "fastload": combo["fastload"],
+        "tester_rc": tester_rc,
+        "tester_duration_s": round(tester_dur, 2),
+        "tester_log": str(tester_log),
+        "validate_rc": validate_rc,
+        "assertions": results,
+        "overall_pass": overall,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+def print_console_table(cfg, results, total_dur):
+    print()
+    print("=" * 80)
+    print(" SDK Tester Matrix - {} - image {}:{}".format(
+        datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        cfg["docker"]["image"].rsplit("/", 1)[-1],
+        cfg["docker"]["tag"],
+    ))
+    print("=" * 80)
+    print(" {:<3} {:<18} {:<10} {:<6} {:<8} {:<8} {}".format(
+        "#", "Input", "Config", "Tester", "Validate", "Duration", "Log"))
+    print(" {:<3} {:<18} {:<10} {:<6} {:<8} {:<8} {}".format(
+        "-" * 3, "-" * 18, "-" * 10, "-" * 6, "-" * 8, "-" * 8, "-" * 20))
+    pass_n = fail_n = 0
+    for i, r in enumerate(results, 1):
+        tester_str = "PASS" if r["tester_rc"] == 0 else "FAIL({})".format(r["tester_rc"])
+        if r["assertions"]:
+            n_ok = sum(1 for a in r["assertions"] if a["ok"] and a["found"])
+            n_total = len(r["assertions"])
+            v_str = "PASS" if n_ok == n_total else "FAIL({}/{})".format(n_ok, n_total)
+        else:
+            v_str = "n/a"
+        d = r["tester_duration_s"]
+        dur_str = "{:02d}:{:02d}".format(int(d) // 60, int(d) % 60)
+        log_short = Path(r["tester_log"]).name
+        print(" {:<3} {:<18} {:<10} {:<6} {:<8} {:<8} {}".format(
+            i, r["input"][:18], r["config"][:10], tester_str, v_str, dur_str, log_short))
+        if r["overall_pass"]:
+            pass_n += 1
+        else:
+            fail_n += 1
+    print(" {:<3} {:<18} {:<10} {:<6} {:<8} {:<8} {}".format(
+        "-" * 3, "-" * 18, "-" * 10, "-" * 6, "-" * 8, "-" * 8, "-" * 20))
+    total_str = "{:02d}:{:02d}".format(int(total_dur) // 60, int(total_dur) % 60)
+    print(" PASS: {}/{}   FAIL: {}/{}   total {}".format(
+        pass_n, len(results), fail_n, len(results), total_str))
+
+    failures = []
+    for r in results:
+        if r["tester_rc"] != 0:
+            failures.append((r["id"], "tester rc={}".format(r["tester_rc"])))
+        for a in r["assertions"]:
+            if not a["found"]:
+                failures.append((r["id"], "assertion not found: {}".format(a["name"])))
+            elif not a["ok"]:
+                failures.append((r["id"], "{} (got {})".format(a["name"], a["count"])))
+
+    if failures:
+        print()
+        print("Failures:")
+        for cid, msg in failures:
+            print("  {:<25} {}".format(cid, msg))
+
+
+def write_results_json(path, cfg, results):
+    payload = {
+        "image": "{}:{}".format(cfg["docker"]["image"], cfg["docker"]["tag"]),
+        "started_at": datetime.now().isoformat(timespec="seconds"),
+        "combos": results,
+    }
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description="Run the Fivetran SDK destination-connector-tester across "
+                    "every (input x config) combo and validate the result.",
+    )
+    here = Path(__file__).resolve().parent
+    p.add_argument("--config", default=str(here / "config.json"),
+                   help="Path to config.json (default: %(default)s).")
+    p.add_argument("--only",
+                   help="Comma-separated list of combo IDs to run "
+                        "(e.g. 'input__FastLoad,dml__TERA').")
+    p.add_argument("--fail-fast", action="store_true",
+                   help="Stop on the first combo that fails. Default: run all "
+                        "12 to give a complete matrix view.")
+    p.add_argument("--purge-generated", action="store_true",
+                   help="Delete the generated directory after a fully-passing run.")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Print the planned combos and the docker argv for each, "
+                        "then exit without running anything.")
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    cfg_path = Path(args.config).resolve()
+    cfg = load_config(cfg_path)
+
+    # Resolve expectations_dir relative to repo root if it's a relative path.
+    exp_dir = Path(cfg["paths"]["expectations_dir"])
+    if not exp_dir.is_absolute():
+        exp_dir = cfg_path.parent.parent.parent / exp_dir
+    cfg["paths"]["expectations_dir"] = str(exp_dir)
+
+    combos = expand_matrix(cfg, only=args.only)
+    if not combos:
+        sys.stderr.write("ERROR: no combos selected.\n")
+        sys.exit(2)
+
+    generated_dir = Path(cfg["paths"]["generated_dir"])
+    generated_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.dry_run:
+        print("Dry run - would execute {} combo(s):".format(len(combos)))
+        for i, c in enumerate(combos, 1):
+            argv = build_docker_argv(cfg, "{}.json".format(c["id"]))
+            print("  [{}] {}".format(i, c["id"]))
+            print("      input    : {}".format(c["input_path"]))
+            print("      tmode    : {}".format(c["tmode"]))
+            print("      fastload : {}".format(c["fastload"]))
+            print("      docker   : {}".format(" ".join(argv)))
+        return 0
+
+    find_tool("docker", "install Docker Desktop or docker-ce")
+    find_tool("bteq", "install Teradata Tools and Utilities")
+    require_port_or_fail(cfg, "startup")
+
+    started = time.time()
+    results = []
+    for i, c in enumerate(combos, 1):
+        try:
+            r = run_combo(cfg, c, generated_dir, i, len(combos))
+        except SystemExit:
+            raise
+        except Exception as e:
+            sys.stderr.write("ERROR running {}: {}\n".format(c["id"], e))
+            r = {
+                "id": c["id"],
+                "input": c["input_name"],
+                "config": "FastLoad" if c["fastload"] else c["tmode"],
+                "tmode": c["tmode"],
+                "fastload": c["fastload"],
+                "tester_rc": -1,
+                "tester_duration_s": 0,
+                "tester_log": "",
+                "validate_rc": -1,
+                "assertions": [],
+                "overall_pass": False,
+            }
+        results.append(r)
+        if args.fail_fast and not r["overall_pass"]:
+            sys.stderr.write("--fail-fast: stopping after combo {}\n".format(c["id"]))
+            break
+
+    total_dur = time.time() - started
+    print_console_table(cfg, results, total_dur)
+
+    results_json = generated_dir / "results.json"
+    write_results_json(results_json, cfg, results)
+    print()
+    print("Results JSON: {}".format(results_json))
+
+    all_pass = all(r["overall_pass"] for r in results) and len(results) == len(combos)
+    if all_pass and args.purge_generated:
+        shutil.rmtree(generated_dir, ignore_errors=True)
+
+    return 0 if all_pass else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sdk_tester_matrix/run.py
+++ b/scripts/sdk_tester_matrix/run.py
@@ -125,11 +125,13 @@ def load_config(path):
             problems.append("teradata.{} not set in config".format(env_key))
             continue
         val = os.environ.get(env_var)
-        if not val:
+        if val is None or val.strip() == "":
             problems.append("env var ${} not set (referenced by teradata.{})"
                             .format(env_var, env_key))
             continue
-        resolved_td[key] = val
+        # Strip whitespace - guards against `set FOO= bar` accidentally
+        # putting a leading space into the value (BTEQ .LOGON rejects it).
+        resolved_td[key] = val.strip()
     cfg["teradata_resolved"] = resolved_td
 
     matrix = cfg.get("matrix", {}) or {}
@@ -435,8 +437,12 @@ def run_tester(cfg, combo, input_filename, generated_dir):
 # ---------------------------------------------------------------------------
 
 def compile_assertions(cfg, expectation):
-    """Build a single BTEQ script that runs every assertion. Each assertion
-    emits one row tagged 'MATRIXASSERT_NNN' followed by the bad-row count.
+    """Build a single BTEQ script that runs every assertion in ONE SELECT
+    with UNION ALL, so column titles print once and the regex parser
+    has the cleanest possible output to scan.
+
+    Each row of the result emits a 'MATRIXASSERT_NNN' tag followed by
+    the bad-row count for that assertion.
     """
     db = cfg["teradata_resolved"]["database"]
     lines = [
@@ -444,17 +450,21 @@ def compile_assertions(cfg, expectation):
         ".SET FORMAT OFF",
         ".SET FOLDLINE OFF",
         ".SET TITLEDASHES OFF",
+        ".SET RTITLE OFF",
         bteq_logon_block(cfg).rstrip("\n"),
         "DATABASE \"{}\";".format(db),
     ]
     assertions = expectation.get("assertions", []) or []
-    for i, a in enumerate(assertions):
-        tag = "{}_{:03d}".format(ASSERT_TAG_PREFIX, i + 1)
-        sql = a["sql"].strip().rstrip(";")
-        lines.append(
-            "SELECT '{}' AS tag_, "
-            "(SELECT COUNT(*) FROM ({}) bad_) AS cnt_;".format(tag, sql)
-        )
+    if assertions:
+        union_parts = []
+        for i, a in enumerate(assertions):
+            tag = "{}_{:03d}".format(ASSERT_TAG_PREFIX, i + 1)
+            sql = a["sql"].strip().rstrip(";")
+            union_parts.append(
+                "SELECT '{}' AS tag_, "
+                "(SELECT COUNT(*) FROM ({}) bad_) AS cnt_".format(tag, sql)
+            )
+        lines.append("\nUNION ALL\n".join(union_parts) + ";")
     lines.append(".LOGOFF")
     lines.append(".QUIT")
     return "\n".join(lines) + "\n"
@@ -514,14 +524,27 @@ def run_combo(cfg, combo, generated_dir, idx, total):
     assertions = expectation.get("assertions", []) or []
     if assertions:
         sql = compile_assertions(cfg, expectation)
-        rc, out, _err = bteq_run(cfg, sql, "{}__assert".format(combo["id"]),
-                                 generated_dir)
+        rc, out, err = bteq_run(cfg, sql, "{}__assert".format(combo["id"]),
+                                generated_dir)
         if rc == BTEQ_RC_CONNECTION:
             sys.stderr.write("ERROR: BTEQ logon failed during validation.\n")
             sys.exit(2)
         results = parse_assertion_results(out, assertions)
         validate_pass = all(r["ok"] and r["found"] for r in results)
         validate_rc = rc
+        # If BTEQ ran but we found ZERO assertion rows, dump diagnostics.
+        # Most likely: bad logon (e.g. whitespace in user), missing privs
+        # on the database, or a SQL error before any UNION-ALL row emitted.
+        n_found = sum(1 for r in results if r["found"])
+        if assertions and n_found == 0:
+            sys.stderr.write(
+                "    !! validation parsed 0 of {} assertions — BTEQ rc={}\n"
+                "    !! see {}/bteq/{}__assert.log\n"
+                "    !! tail of BTEQ output:\n".format(
+                    len(assertions), rc, generated_dir, combo["id"]))
+            tail_lines = (out or "").splitlines()[-30:]
+            for line in tail_lines:
+                sys.stderr.write("        {}\n".format(line))
     else:
         results = []
         validate_pass = tester_rc == 0

--- a/scripts/sdk_tester_matrix/run.py
+++ b/scripts/sdk_tester_matrix/run.py
@@ -290,8 +290,14 @@ def drop_tester_tables(cfg, combo_id, generated_dir):
 # ---------------------------------------------------------------------------
 
 def write_configuration_json(cfg, combo, generated_dir):
-    """Write C:\\Fivetran\\configuration.json (the tester reads this) plus an
-    archive copy under generated_dir/configurations/<combo_id>.json.
+    """Write <docker.mount_source>/configuration.json (the tester reads this
+    via the bind mount) plus an archive copy under
+    generated_dir/configurations/<combo_id>.json.
+
+    Goes to docker.mount_source, NOT canonical_inputs_dir, since canonical
+    inputs are vendored in the repo and must stay clean. The mount source
+    directory is created if it doesn't exist (docker can't bind-mount a
+    missing path on Windows).
     """
     td = cfg["teradata_resolved"]
     contents = dict(cfg["configuration_template"])
@@ -302,8 +308,9 @@ def write_configuration_json(cfg, combo, generated_dir):
     contents["tmode"] = combo["tmode"]
     contents["use.fastload"] = "true" if combo["fastload"] else "false"
 
-    canonical_dir = Path(cfg["paths"]["canonical_inputs_dir"])
-    live_path = canonical_dir / "configuration.json"
+    mount_source = Path(cfg["docker"]["mount_source"])
+    mount_source.mkdir(parents=True, exist_ok=True)
+    live_path = mount_source / "configuration.json"
     live_path.write_text(json.dumps(contents, indent=4), encoding="utf-8")
 
     archive_dir = generated_dir / "configurations"
@@ -696,6 +703,14 @@ def main():
 
     generated_dir = Path(cfg["paths"]["generated_dir"])
     generated_dir.mkdir(parents=True, exist_ok=True)
+
+    # Ensure the docker bind-mount source exists. Docker on Windows refuses
+    # to bind-mount a non-existent host path - on a fresh checkout the
+    # `C:\Fivetran` directory may not exist yet. Create it now so the
+    # container can mount it; per-combo writes (configuration.json, patched
+    # input JSONs) land here.
+    mount_source = Path(cfg["docker"]["mount_source"])
+    mount_source.mkdir(parents=True, exist_ok=True)
 
     if args.dry_run:
         print("Dry run - would execute {} combo(s):".format(len(combos)))

--- a/scripts/sdk_tester_matrix/run.py
+++ b/scripts/sdk_tester_matrix/run.py
@@ -340,11 +340,16 @@ def _strip_lob_columns(node, lob_names):
     return node
 
 
-def patch_input(combo, expectation, generated_dir):
+def patch_input(cfg, combo, expectation, generated_dir):
     """Read the canonical input JSON, fix the upstream `[B@xxx` byte[].toString()
     junk via patch_tester_inputs, optionally strip LOB columns, and write to
-    canonical_inputs_dir/<combo_id>.json so docker sees it via the bind mount.
-    Returns the file name (relative to canonical_inputs_dir) for --input-file.
+    docker.mount_source/<combo_id>.json so docker sees it via the bind mount.
+    Returns the file name (relative to mount target) for --input-file.
+
+    Canonical inputs are vendored under scripts/sdk_tester_matrix/inputs/ and
+    therefore checked into the repo - this function MUST NOT write back to
+    that directory. The patched copy goes into the docker bind-mount source
+    on the host filesystem instead.
     """
     src = combo["input_path"]
     if not src.is_file():
@@ -361,16 +366,18 @@ def patch_input(combo, expectation, generated_dir):
     if lob and combo["fastload"]:
         patched = _strip_lob_columns(patched, lob)
 
-    # Archive the patched copy under generated/inputs/, AND drop it next to
-    # the canonical so docker's bind mount sees it.
+    # Archive the patched copy under generated/inputs/ for post-mortem.
     inputs_archive = generated_dir / "inputs"
     inputs_archive.mkdir(parents=True, exist_ok=True)
     archive_path = inputs_archive / "{}.json".format(combo["id"])
     archive_path.write_text(json.dumps(patched, indent=2), encoding="utf-8")
 
-    canonical_dir = src.parent
+    # Drop the patched copy into the docker bind-mount source so the
+    # tester (running inside the container) reads it via the mount.
+    mount_source = Path(cfg["docker"]["mount_source"])
+    mount_source.mkdir(parents=True, exist_ok=True)
     live_name = "{}.json".format(combo["id"])
-    live_path = canonical_dir / live_name
+    live_path = mount_source / live_name
     live_path.write_text(json.dumps(patched, indent=2), encoding="utf-8")
 
     return live_name, counter[0]
@@ -514,7 +521,7 @@ def run_combo(cfg, combo, generated_dir, idx, total):
 
     drop_tester_tables(cfg, combo["id"], generated_dir)
     write_configuration_json(cfg, combo, generated_dir)
-    input_filename, junk_replaced = patch_input(combo, expectation, generated_dir)
+    input_filename, junk_replaced = patch_input(cfg, combo, expectation, generated_dir)
     if junk_replaced:
         sys.stderr.write("    (patched {} byte[].toString() junk values)\n"
                          .format(junk_replaced))

--- a/scripts/sdk_tester_matrix/run.py
+++ b/scripts/sdk_tester_matrix/run.py
@@ -437,11 +437,13 @@ def run_tester(cfg, combo, input_filename, generated_dir):
 # ---------------------------------------------------------------------------
 
 def compile_assertions(cfg, expectation):
-    """Build a single BTEQ script that runs every assertion in ONE SELECT
-    with UNION ALL, so column titles print once and the regex parser
-    has the cleanest possible output to scan.
+    """Build a BTEQ script that runs each assertion as its own SELECT
+    statement. One bad assertion (compile error, missing column, etc.)
+    therefore can't kill the others - BTEQ continues to the next
+    statement and the matching ones still emit their MATRIXASSERT_NNN
+    rows for the parser to scan.
 
-    Each row of the result emits a 'MATRIXASSERT_NNN' tag followed by
+    Each assertion's row pattern: 'MATRIXASSERT_NNN' tag followed by
     the bad-row count for that assertion.
     """
     db = cfg["teradata_resolved"]["database"]
@@ -455,16 +457,13 @@ def compile_assertions(cfg, expectation):
         "DATABASE \"{}\";".format(db),
     ]
     assertions = expectation.get("assertions", []) or []
-    if assertions:
-        union_parts = []
-        for i, a in enumerate(assertions):
-            tag = "{}_{:03d}".format(ASSERT_TAG_PREFIX, i + 1)
-            sql = a["sql"].strip().rstrip(";")
-            union_parts.append(
-                "SELECT '{}' AS tag_, "
-                "(SELECT COUNT(*) FROM ({}) bad_) AS cnt_".format(tag, sql)
-            )
-        lines.append("\nUNION ALL\n".join(union_parts) + ";")
+    for i, a in enumerate(assertions):
+        tag = "{}_{:03d}".format(ASSERT_TAG_PREFIX, i + 1)
+        sql = a["sql"].strip().rstrip(";")
+        lines.append(
+            "SELECT '{}' AS tag_, "
+            "(SELECT COUNT(*) FROM ({}) bad_) AS cnt_;".format(tag, sql)
+        )
     lines.append(".LOGOFF")
     lines.append(".QUIT")
     return "\n".join(lines) + "\n"

--- a/scripts/sdk_tester_matrix/run.py
+++ b/scripts/sdk_tester_matrix/run.py
@@ -471,8 +471,10 @@ def compile_assertions(cfg, expectation):
 
 
 _TAG_RE = re.compile(
-    r"^\s*" + ASSERT_TAG_PREFIX + r"_(\d{3})\s+(\d+)\s*$",
-    re.MULTILINE,
+    # Tolerant matcher: anywhere on a line, MATRIXASSERT_NNN followed by any
+    # whitespace and then digits. BTEQ sometimes pads the literal column to
+    # CHAR(N), wraps the count in spaces, etc. - all fine.
+    ASSERT_TAG_PREFIX + r"_(\d{3})\s+(\d+)\b",
 )
 
 
@@ -538,13 +540,17 @@ def run_combo(cfg, combo, generated_dir, idx, total):
         n_found = sum(1 for r in results if r["found"])
         if assertions and n_found == 0:
             sys.stderr.write(
-                "    !! validation parsed 0 of {} assertions — BTEQ rc={}\n"
+                "    !! validation parsed 0 of {} assertions - BTEQ rc={}\n"
                 "    !! see {}/bteq/{}__assert.log\n"
-                "    !! tail of BTEQ output:\n".format(
+                "    !! tail of BTEQ stdout:\n".format(
                     len(assertions), rc, generated_dir, combo["id"]))
-            tail_lines = (out or "").splitlines()[-30:]
+            tail_lines = (out or "").splitlines()[-40:]
             for line in tail_lines:
                 sys.stderr.write("        {}\n".format(line))
+            if err and err.strip():
+                sys.stderr.write("    !! BTEQ stderr:\n")
+                for line in err.splitlines()[-20:]:
+                    sys.stderr.write("        {}\n".format(line))
     else:
         results = []
         validate_pass = tester_rc == 0

--- a/scripts/sdk_tester_matrix/run.py
+++ b/scripts/sdk_tester_matrix/run.py
@@ -19,7 +19,8 @@ Prereqs
 -------
   * `bteq` and `docker` on PATH
   * Connector JAR running on port 50052 (in another terminal)
-  * Env vars: TD_HOST, TD_USER, TD_PASSWORD, TD_DATABASE
+  * Env vars: TERADATA_HOST, TERADATA_USER, TERADATA_PASSWORD, TERADATA_DATABASE
+    (same names IntegrationTestBase already uses)
   * The 4 canonical input JSONs in C:\\Fivetran (or whichever
     paths.canonical_inputs_dir is set to in config.json)
 
@@ -295,6 +296,7 @@ def write_configuration_json(cfg, combo, generated_dir):
     contents["host"] = td["host"]
     contents["user"] = td["user"]
     contents["td2password"] = td["password"]
+    contents["database"] = td["database"]
     contents["tmode"] = combo["tmode"]
     contents["use.fastload"] = "true" if combo["fastload"] else "false"
 

--- a/src/main/java/com/teradata/fivetran/destination/writers/FastLoadDataWriter.java
+++ b/src/main/java/com/teradata/fivetran/destination/writers/FastLoadDataWriter.java
@@ -191,7 +191,18 @@ public class FastLoadDataWriter {
                     createTempTableSQL , e);
         }
 
-        String beginLoading = String.format("BEGIN LOADING %s ERRORFILES %s, %s WITH INTERVAL", outputTableName, errorTable1, errorTable2);
+        // Qualify temp + ERR table names with the target database. The FastLoad
+        // session (lsnConnection) is opened without a default-database setting,
+        // so its default database is the JDBC user's home. When `database` config
+        // points elsewhere (e.g. configurationMap.database != user-home), an
+        // unqualified BEGIN LOADING resolves to the wrong table and Teradata
+        // rejects it with Error 3614 ("Statement permitted only during FastLoad
+        // or MLoad") because the LSN reservation was made for a table in the
+        // configured database.
+        String beginLoading = String.format("BEGIN LOADING %s ERRORFILES %s, %s WITH INTERVAL",
+                TeradataJDBCUtil.escapeTable(database, outputTableName),
+                TeradataJDBCUtil.escapeTable(database, errorTable1),
+                TeradataJDBCUtil.escapeTable(database, errorTable2));
         String endLoading = "END LOADING";
 
         String lsnUrl = "jdbc:teradata://" + dbsHost
@@ -363,9 +374,17 @@ public class FastLoadDataWriter {
              Logger.logMessage(Logger.LogLevel.INFO,"\nTASM Governed: " + governedValue);
             boolean isGoverned = "true".equals(governedValue);
 
-            // Build check workload statement
-            String checkWorkload = CHECK_WORKLOAD + SQL_BEGIN_LOADING + " " + outputTableName
-                    + " ERRORFILES " + errorTable1 + ", " + errorTable2;
+            // Build check workload statement. Qualify table names with the
+            // target database for the same reason as BEGIN LOADING above:
+            // unqualified names resolve against the JDBC user's home database,
+            // which is wrong when the connector is configured to use a
+            // different database via configurationMap.database.
+            String checkWorkload = CHECK_WORKLOAD + SQL_BEGIN_LOADING + " "
+                    + TeradataJDBCUtil.escapeTable(database, outputTableName)
+                    + " ERRORFILES "
+                    + TeradataJDBCUtil.escapeTable(database, errorTable1)
+                    + ", "
+                    + TeradataJDBCUtil.escapeTable(database, errorTable2);
 
             String checkWorkloadEnd = (!isGoverned ? "{fn teradata_failfast}" : "") + CHECK_WORKLOAD_END;
 

--- a/src/main/java/com/teradata/fivetran/destination/writers/FastLoadDataWriter.java
+++ b/src/main/java/com/teradata/fivetran/destination/writers/FastLoadDataWriter.java
@@ -673,11 +673,18 @@ public class FastLoadDataWriter {
      * @return USING INSERT SQL statement, or null if no valid columns found
      */
     private static String getusingInsertSQL(Connection con, String database, String outputTableName, List<String> header) {
+        // Qualify the temp-table name for any SQL prepared/executed on this
+        // FastLoad LSN session. Mirrors the BEGIN LOADING / CHECK WORKLOAD
+        // fix: the LSN session has no default database set, so unqualified
+        // references resolve to the JDBC user's home DB and fail with 3807
+        // when `database` config points elsewhere.
+        String qualifiedOutputTable = TeradataJDBCUtil.escapeTable(database, outputTableName);
         try {
             Statement stmt = con.createStatement();
-            Logger.logMessage(Logger.LogLevel.INFO,"Query: " + "select count(*) from dbc.ColumnsV where tablename='" + database + "." + outputTableName + "';");
-            ResultSet res = stmt
-                    .executeQuery("select count(*) from dbc.columns where tablename='" + database + "." + outputTableName + "';");
+            String countQuery = "select count(*) from dbc.ColumnsV where databasename='" + database
+                    + "' and tablename='" + outputTableName + "'";
+            Logger.logMessage(Logger.LogLevel.INFO, "Query: " + countQuery);
+            ResultSet res = stmt.executeQuery(countQuery);
             res.next();
             Logger.logMessage(Logger.LogLevel.INFO,"Total columns in table " + outputTableName + ": " + res.getInt(1));
 
@@ -695,7 +702,8 @@ public class FastLoadDataWriter {
             if (availableColumns.isEmpty()) {
                 Logger.logMessage(Logger.debugLogLevel, "No columns found in table: " + outputTableName);
                 Thread.sleep(10000); // wait for 10 seconds before retrying
-                res = stmt.executeQuery("select columnName from dbc.columns where tablename='" + outputTableName + "';");
+                res = stmt.executeQuery("select columnName from dbc.ColumnsV where databasename='" + database
+                        + "' and tablename='" + outputTableName + "'");
                 while (res.next()) {
                     Logger.logMessage(Logger.LogLevel.INFO, "Found column in table after wait: " + res.getString("columnName"));
                     availableColumns.add(res.getString("columnName").trim());
@@ -730,7 +738,7 @@ public class FastLoadDataWriter {
                 colNames[i] = "\"" + orderedColumns.get(i) + "\"";
             }
 
-            TeradataColumnDesc[] fieldDescs = getColumnDesc(outputTableName, colNames, con);
+            TeradataColumnDesc[] fieldDescs = getColumnDesc(qualifiedOutputTable, colNames, con);
             String[] fieldTypes4Using = new String[fieldDescs.length];
             String[] fieldNames = new String[fieldDescs.length];
 
@@ -768,7 +776,7 @@ public class FastLoadDataWriter {
 
             Logger.logMessage(Logger.LogLevel.INFO,"Field Names: " + Arrays.toString(fieldNames));
             Logger.logMessage(Logger.LogLevel.INFO,"Field Types: " + Arrays.toString(fieldTypes4Using));
-            return getUsingSQL(outputTableName, fieldNames, fieldTypes4Using, "UTF-8");
+            return getUsingSQL(qualifiedOutputTable, fieldNames, fieldTypes4Using, "UTF-8");
         } catch (SQLException sqle) {
             sqle.printStackTrace();
         } catch (InterruptedException e) {


### PR DESCRIPTION
## Summary
Bundles two related Jiras: a new SDK Tester Matrix orchestrator (IDE-26063) and the FastLoad silent-data-loss fix (IDE-26074) that the matrix uncovered on
 its first end-to-end run.
- **IDE-26063** — `scripts/sdk_tester_matrix/run.py`: stdlib-only Python orchestrator that runs the full 4-input × 3-config matrix (ANSI / TERA /FastLoad) against a single long-lived JAR, validates via BTEQ assertions, and produces a pass/fail report. Replaces the manual ~half-day ritual with one ~28 min command.
- **IDE-26074** — `FastLoadDataWriter.java`: qualifies temp/error-table references on the FastLoad LSN session with `escapeTable(database, name)`. Fixes silent data loss when the configured `database` differs from the JDBC user's home DB. Two waves: `BEGIN LOADING` / `CHECK WORKLOAD` (commit `6f35ae1`) and `getusingInsertSQL` paths (`getColumnDesc`, `getUsingSQL`, two `dbc.ColumnsV` diagnostics — commit `2cd2b2f`).
- Adds vendored canonical SDK inputs in `scripts/sdk_tester_matrix/inputs/` so adding a new test case is a "drop file in folder" operation.
- Adds wiki-style user guide at `docs/sdk-tester-matrix-guide.md`.

## Why this is one PR
IDE-26074 was uncovered by IDE-26063 — the matrix was the diagnostic that surfaced the silent-data-loss bug that manual spot-checks had been missing. They were developed and verified together; merging them as one bundle keeps the regression test (the matrix) and the fix it caught (FastLoad qualified names) atomic.

## Test plan
- [x] `gradle build` — 105 integration tests, 0 failures (full suite against live Teradata).
- [x] SDK Tester Matrix — 12/12 combos PASS in 28m 22s (4 inputs × {ANSI, TERA, FastLoad}).
- [x] All 3 FastLoad combos (`input__FastLoad`, `dml__FastLoad`, `sync_modes__FastLoad`) — previously dropped data silently, now confirmed populating
target tables correctly via direct BTEQ row-count checks.
- [x] `--only <subset>` confirmed working for re-running specific combos.
- [x] `--dry-run` confirmed prints planned combos without executing.
- [x] Stop-the-JAR-mid-matrix confirms next combo's port probe hard-fails with exit 2 (no hang).

## Files changed
- **Test framework (new)**: `scripts/sdk_tester_matrix/{run.py, config.json, README.md}`, vendored inputs, expectation files,
`scripts/patch_tester_inputs.py`, `docs/sdk-tester-matrix-guide.md`.
- **FastLoad fix**: `src/main/java/com/teradata/fivetran/destination/writers/FastLoadDataWriter.java`.
- `.gitignore` updated for `generated/` and matrix runtime artifacts.

## Risk
- FastLoad fix is a pure bug fix — no schema, API, or config changes. Behavior identical for setups where `database` == JDBC user home (the only case that worked before).
- Matrix is additive (new files under `scripts/sdk_tester_matrix/`) — no existing CI / build path impacted.